### PR TITLE
refactor vercel log and deploy lookups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "ai-dev-agent",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-dev-agent",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.11.0",
         "dotenv": "^17.2.1",
-        "gpt-3-encoder": "^1.1.4",
         "openai": "^4.104.0",
         "simple-git": "^3.28.0"
       }
@@ -332,12 +331,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/gpt-3-encoder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/gpt-3-encoder/-/gpt-3-encoder-1.1.4.tgz",
-      "integrity": "sha512-fSQRePV+HUAhCn7+7HL7lNIXNm6eaFWFbNLOOGtmSJ0qJycyQvj60OvRlH7mee8xAMjBDNRdMXlMwjAbMTDjkg==",
-      "license": "MIT"
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "axios": "^1.11.0",
     "dotenv": "^17.2.1",
     "openai": "^4.104.0",
-    "simple-git": "^3.28.0",
-    "gpt-3-encoder": "^1.1.4"
+    "simple-git": "^3.28.0"
   }
 }


### PR DESCRIPTION
## Summary
- simplify build log retrieval to v3 events endpoint and drop version fallbacks
- use v6 deployments API and stage deletions with `git add -A`
- drop gpt-3-encoder dependency and handle OpenAI rate limits via class check

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6894e4318d58832a83fb3ba61af8694a