### PR TITLE
fix: enforce readFileTree max file limit

### DIFF
--- a/automation/ai-iter-agent.cjs
+++ b/automation/ai-iter-agent.cjs
@@ -277,6 +277,7 @@ function decideMode(buildLog, runtimeLog, depState) {
  - Mode=UPGRADE: incrementally migrate the codebase and dependencies toward Next.js 14 while keeping the app functional, tackling meaningful chunks each step.
  - Prefer UNIFIED DIFF. If unsure or file context may be stale, provide "files" with full contents.
  - live site is here: https://simple-pim-1754492683911.vercel.app .
+ - Include a concise commit_message summarizing the specific fix or feature implemented.
  - Always return valid JSON only.`;
 
   const user =

--- a/readFileTree.js
+++ b/readFileTree.js
@@ -29,7 +29,8 @@ export async function readFileTree(
       }
 
       if (entry.isDirectory()) {
-        await walk(fullPath);
+        const shouldContinue = await walk(fullPath);
+        if (!shouldContinue) return false;
       } else if (entry.isFile()) {
         try {
           const content = await fs.readFile(fullPath, 'utf8');
@@ -40,12 +41,14 @@ export async function readFileTree(
           });
 
           // Limit total number of files
-          if (result.length >= maxFiles) return;
+          if (result.length >= maxFiles) return false;
         } catch (err) {
           console.warn(`Could not read file ${fullPath}: ${err.message}`);
         }
       }
     }
+
+    return true;
   }
 
   await walk(dir);


### PR DESCRIPTION
## Summary
- stop walking file tree after hitting maxFiles limit to avoid unnecessary reads
- guide automation script to produce descriptive commit messages summarizing changes

## Testing
- `node --check automation/ai-iter-agent.cjs`
- `node --input-type=module -e "import { readFileTree } from './readFileTree.js'; readFileTree('.', {maxFiles: 3}).then(r => console.log('files', r.length));"`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68977d59d864832a9f0699bbda17fb45