### PR TITLE
chore: default to gpt-5-mini

### DIFF
--- a/automation/ai-iter-agent.cjs
+++ b/automation/ai-iter-agent.cjs
@@ -4,8 +4,8 @@
  * Minor update: when the AI patch is “not applicable”, we auto-retry with a
  * files[]-only request (full file bodies), then build-gate and push.
  *
- * Model update: default model -> gpt-5 (override with OPENAI_MODEL or AI_MODEL).
- * Compatibility: for gpt-5, omit temperature (model only supports default).
+ * Model update: default model -> gpt-5-mini (override with OPENAI_MODEL or AI_MODEL).
+ * Compatibility: for gpt-5-mini, omit temperature (model only supports default).
  *
  * New: optional UPGRADE mode for migrating the target app toward modern
  * Next.js versions (e.g., 14).
@@ -23,8 +23,8 @@ const {
   VERCEL_PROJECT, // project name or prj_ id
   TARGET_REPO = "basstian-ai/simple-pim-1754492683911",
   TARGET_BRANCH = "main",
-  // Default model now gpt-5; OPENAI_MODEL or AI_MODEL can override
-  AI_MODEL = process.env.OPENAI_MODEL || process.env.AI_MODEL || "gpt-5",
+  // Default model now gpt-5-mini; OPENAI_MODEL or AI_MODEL can override
+  AI_MODEL = process.env.OPENAI_MODEL || process.env.AI_MODEL || "gpt-5-mini",
   AGENT_MAX_PROMPT_CHARS = parseInt(process.env.AGENT_MAX_PROMPT_CHARS || "45000", 10),
   AGENT_RETRY = parseInt(process.env.AGENT_RETRY || "3", 10),
   AGENT_MODE,
@@ -140,13 +140,13 @@ async function askAI(system, user) {
     model: AI_MODEL,
     messages: [{ role: "system", content: system }, { role: "user", content: user }],
     response_format: { type: "json_object" },
-    // temperature may not be supported for all models (e.g., gpt-5). We add it only if allowed.
+    // temperature may not be supported for all models (e.g., gpt-5-mini). We add it only if allowed.
   };
 
   const isGpt5 = /^gpt-5($|[-_])/i.test(AI_MODEL);
   const candidateBodies = [];
 
-  // If not gpt-5, try with temperature first (more deterministic).
+  // If not gpt-5-mini, try with temperature first (more deterministic).
   if (!isGpt5) {
     candidateBodies.push({ ...baseBody, temperature: 0.2 });
   }


### PR DESCRIPTION
## Summary
- default AI model to gpt-5-mini
- adjust comments to reference gpt-5-mini model and temperature handling

## Testing
- `node - <<'NODE'
function resolve(env){
  const { OPENAI_MODEL, AI_MODEL: AI_MODEL_ENV } = env;
  const AI_MODEL = OPENAI_MODEL || AI_MODEL_ENV || "gpt-5-mini";
  return AI_MODEL;
}
console.log('default:', resolve({}));
console.log('AI_MODEL override:', resolve({AI_MODEL:'bar'}));
console.log('OPENAI_MODEL override:', resolve({OPENAI_MODEL:'foo'}));
console.log('Both overrides (OPENAI_MODEL precedence):', resolve({OPENAI_MODEL:'foo', AI_MODEL:'bar'}));
NODE`
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_6899ae01bc68832abf87dc987f624642