### PR TITLE
chore: clarify gpt-5 family temperature handling

### DIFF
--- a/automation/ai-iter-agent.cjs
+++ b/automation/ai-iter-agent.cjs
@@ -4,7 +4,7 @@
  * Minor update: when the AI patch is “not applicable”, we auto-retry with a
  * files[]-only request (full file bodies), then build-gate and push.
  *
- * Model update: default model -> gpt-5 (override with OPENAI_MODEL or AI_MODEL).
+ * Model update: default model -> gpt-5-mini (override with OPENAI_MODEL or AI_MODEL).
  * Compatibility: for gpt-5 family (gpt-5 and gpt-5-mini), omit temperature (models only support default).
  *
  * New: optional UPGRADE mode for migrating the target app toward modern
@@ -23,8 +23,8 @@ const {
   VERCEL_PROJECT, // project name or prj_ id
   TARGET_REPO = "basstian-ai/simple-pim-1754492683911",
   TARGET_BRANCH = "main",
-  // Default model now gpt-5; OPENAI_MODEL or AI_MODEL can override
-  AI_MODEL = process.env.OPENAI_MODEL || process.env.AI_MODEL || "gpt-5",
+  // Default model now gpt-5-mini; OPENAI_MODEL or AI_MODEL can override
+  AI_MODEL = process.env.OPENAI_MODEL || process.env.AI_MODEL || "gpt-5-mini",
   AGENT_MAX_PROMPT_CHARS = parseInt(process.env.AGENT_MAX_PROMPT_CHARS || "45000", 10),
   AGENT_RETRY = parseInt(process.env.AGENT_RETRY || "3", 10),
   AGENT_MODE,

--- a/automation/ai-iter-agent.cjs
+++ b/automation/ai-iter-agent.cjs
@@ -5,7 +5,7 @@
  * files[]-only request (full file bodies), then build-gate and push.
  *
  * Model update: default model -> gpt-5 (override with OPENAI_MODEL or AI_MODEL).
- * Compatibility: for gpt-5, omit temperature (model only supports default).
+ * Compatibility: for gpt-5 family (gpt-5 and gpt-5-mini), omit temperature (models only support default).
  *
  * New: optional UPGRADE mode for migrating the target app toward modern
  * Next.js versions (e.g., 14).
@@ -140,14 +140,15 @@ async function askAI(system, user) {
     model: AI_MODEL,
     messages: [{ role: "system", content: system }, { role: "user", content: user }],
     response_format: { type: "json_object" },
-    // temperature may not be supported for all models (e.g., gpt-5). We add it only if allowed.
+    // temperature may not be supported for all models (e.g., gpt-5 family). We add it only if allowed.
   };
 
-  const isGpt5 = /^gpt-5($|[-_])/i.test(AI_MODEL);
+  // gpt-5 and gpt-5-mini require the default temperature
+  const isGpt5Family = /^gpt-5($|[-_])/i.test(AI_MODEL);
   const candidateBodies = [];
 
-  // If not gpt-5, try with temperature first (more deterministic).
-  if (!isGpt5) {
+  // If not gpt-5 family, try with temperature first (more deterministic).
+  if (!isGpt5Family) {
     candidateBodies.push({ ...baseBody, temperature: 0.2 });
   }
   // Always add a fallback without temperature (works for all models).


### PR DESCRIPTION
## Summary
- rename `isGpt5` flag to `isGpt5Family`
- document that gpt-5 and gpt-5-mini require default temperature
- keep temperature logic off for gpt-5 family models

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899ae1dbffc832ab144996f6ab68b76