### PR TITLE
docs: reference gpt-5-mini in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ High-Level Workflow & Intent
 	•	Mode (FIX or FEATURE).
 	•	Logs (build/runtime trimmed).
 	•	Repo file list & key file snippets.
-	4.	Ask OpenAI model (now gpt-5) for a patch:
+	4.	Ask OpenAI model (now gpt-5-mini) for a patch:
 	•	Prefer unified_diff.
 	•	If diff fails → retry with files[] containing full file content.
 	5.	Apply changes:


### PR DESCRIPTION
## Summary
- update README to reference gpt-5-mini instead of gpt-5 for patch requests

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899ae22ec68832a9ff2574d97524143