### PR TITLE
feat: parse vercel build logs for duplicates

### DIFF
--- a/automation/ai-iter-agent.cjs
+++ b/automation/ai-iter-agent.cjs
@@ -133,6 +133,33 @@ function runtimeLogsCLI(url) {
   return r.out || "";
 }
 
+function parseBuildLog(log) {
+  const lines = (log || "").split("\n");
+  const warnings = [];
+  const errors = [];
+  const duplicates = [];
+  const importErrors = [];
+  for (const line of lines) {
+    const l = line.toLowerCase();
+    if (l.includes("warning")) warnings.push(line.trim());
+    if (l.includes("error")) errors.push(line.trim());
+    if (l.includes("duplicate")) duplicates.push(line.trim());
+    if (
+      l.includes("module not found") ||
+      l.includes("cannot find module") ||
+      l.includes("can't resolve") ||
+      (l.includes("import") && l.includes("error"))
+    ) importErrors.push(line.trim());
+  }
+  const uniq = arr => [...new Set(arr)];
+  return {
+    warnings: uniq(warnings),
+    errors: uniq(errors),
+    duplicates: uniq(duplicates),
+    importErrors: uniq(importErrors),
+  };
+}
+
 // ---------- AI ----------
 async function askAI(system, user) {
   const baseBody = {
@@ -242,6 +269,13 @@ function decideMode(buildLog, runtimeLog, depState) {
   log("\n=== Sync target repo ===\n");
   syncTarget();
 
+  let prevIssueNote = "";
+  try {
+    const prev = JSON.parse(readFileSync(`${TARGET_DIR}/vercel_build_issues.json`, "utf8"));
+    const prevLines = [...(prev.duplicates || []), ...(prev.importErrors || [])];
+    if (prevLines.length) prevIssueNote = prevLines.join("\n");
+  } catch {}
+
   log("\n=== Fetch latest Vercel deployment & logs ===\n");
   let buildLog = "", runtimeLog = "", depMeta = "n/a", depState = "UNKNOWN";
   try {
@@ -264,6 +298,8 @@ function decideMode(buildLog, runtimeLog, depState) {
   }
   safeWrite(`${TARGET_DIR}/vercel_build.log`, buildLog || "(no build logs)");
   safeWrite(`${TARGET_DIR}/vercel_runtime.log`, runtimeLog || "(no runtime logs)");
+  const buildIssues = parseBuildLog(buildLog);
+  safeWrite(`${TARGET_DIR}/vercel_build_issues.json`, JSON.stringify(buildIssues, null, 2));
   log("📝 Build/runtime logs saved.");
 
   const mode = decideMode(buildLog, runtimeLog, depState);
@@ -286,10 +322,17 @@ function decideMode(buildLog, runtimeLog, depState) {
  - Live site: https://simple-pim-1754492683911.vercel.app.
  - Return valid JSON containing a concise commit_message and either unified_diff or files[].`;
 
+  const issueSummary = [];
+  if (buildIssues.duplicates.length) issueSummary.push(`Duplicates:\n${buildIssues.duplicates.join("\n")}`);
+  if (buildIssues.importErrors.length) issueSummary.push(`Import errors:\n${buildIssues.importErrors.join("\n")}`);
+  const parsedIssues = issueSummary.join("\n");
+
   const user =
 `Context:
 Mode: ${mode}
 Deployment: ${depMeta}
+${prevIssueNote ? `\nPrevious duplicates/import errors:\n${prevIssueNote}` : ""}
+${parsedIssues ? `\nParsed build issues:\n${parsedIssues}` : ""}
 
 Build log (trimmed):
 ${trim(buildLog, Math.floor(AGENT_MAX_PROMPT_CHARS * 0.45))}


### PR DESCRIPTION
## Summary
- parse Vercel build logs for warnings, errors, duplicate messages, and import failures
- save parsed build issues for later runs and include previous duplicate/import errors in the AI prompt

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899c7657ce8832a8731b22e2093ba5a