### PR TITLE
Log default OpenAI model when env vars missing

### DIFF
--- a/automation/ai-iter-agent.cjs
+++ b/automation/ai-iter-agent.cjs
@@ -29,6 +29,10 @@ const {
   AGENT_MODE,
 } = process.env;
 
+if (!process.env.OPENAI_MODEL && !process.env.AI_MODEL) {
+  log(`Using default model ${AI_MODEL}; override by setting OPENAI_MODEL or AI_MODEL.`);
+}
+
 if (!OPENAI_API_KEY) die("Missing OPENAI_API_KEY");
 
 const ROOT = process.cwd();


### PR DESCRIPTION
## Summary
- log when neither OPENAI_MODEL nor AI_MODEL is set, noting default model and override instructions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check automation/ai-iter-agent.cjs`


------
https://chatgpt.com/codex/tasks/task_e_6899e98d47c4832a99b2b9bc2ed46adb