### PR TITLE
Fix diff chunk splitting for first file

### DIFF
--- a/automation/lib/utils.cjs
+++ b/automation/lib/utils.cjs
@@ -102,7 +102,9 @@ function splitDiffIntoFiles(sanitized) {
   // Split into per-file chunks (keep the "diff --git" marker with each)
   const normalized = sanitized.replace(/^diff --git /, '\n\0diff --git ');
   const parts = normalized.split(/\n(?=diff --git )/g);
-  return parts.map(p => p.replace(/^\0/, '')).filter(Boolean);
+  // Each chunk may start with an injected "\0" and/or leading newline.
+  // Strip those so downstream logic sees a clean "diff --git" header.
+  return parts.map(p => p.replace(/^[\n\0]+/, '')).filter(Boolean);
 }
 
 function parseChunkPaths(chunk) {


### PR DESCRIPTION
## Summary
- handle leading newline/null markers in diff splitter so first file patch applies correctly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ae04ba718832aab179b5db57ae7e2