### PR TITLE
feat: validate vercel env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Vercel (for log ingestion)
 - `VERCEL_TOKEN` – Vercel token with read access
 - `VERCEL_PROJECT_ID` – Project ID of the PIM app
 
+Both variables are required to fetch Vercel logs. If neither is set, the agent will continue but skip log ingestion. If only one is provided, the agent exits with an error.
+
 Target repo (where diffs are applied)
 
 - `TARGET_REPO_DIR` – path to the PIM repo (default: `../simple-pim-1754492683911`)

--- a/automation/ai-iter-agent.cjs
+++ b/automation/ai-iter-agent.cjs
@@ -32,6 +32,16 @@ if (!OPENAI_API_KEY) {
   process.exit(1);
 }
 
+if (!VERCEL_TOKEN && !VERCEL_PROJECT_ID) {
+  console.warn('Missing VERCEL_TOKEN and VERCEL_PROJECT_ID; skipping Vercel log ingestion.');
+} else if (!VERCEL_TOKEN) {
+  console.error('VERCEL_TOKEN is required when VERCEL_PROJECT_ID is set.');
+  process.exit(1);
+} else if (!VERCEL_PROJECT_ID) {
+  console.error('VERCEL_PROJECT_ID is required when VERCEL_TOKEN is set.');
+  process.exit(1);
+}
+
 async function callLLM({ system, payload }) {
   const body = {
     model: OPENAI_MODEL, // keep gpt-5-mini


### PR DESCRIPTION
## Summary
- warn when Vercel env vars are missing and exit on partial config
- document Vercel env var requirements in README

## Testing
- `OPENAI_API_KEY=dummy TARGET_REPO_DIR=. node automation/ai-iter-agent.cjs` *(fails: fetch failed)*
- `OPENAI_API_KEY=dummy VERCEL_TOKEN=foo VERCEL_PROJECT_ID=bar TARGET_REPO_DIR=. node automation/ai-iter-agent.cjs` *(fails: fetch failed)*


------
https://chatgpt.com/codex/tasks/task_e_689af91bb108832a8d3fa36652edaa43