### PR TITLE
chore: surface vercel runtime log errors

### DIFF
--- a/automation/ai-iter-agent.cjs
+++ b/automation/ai-iter-agent.cjs
@@ -89,7 +89,11 @@ async function fetchVercelLogs() {
   const id = d.uid || d.id;
   const buildText = await getBuildEvents({ token: VERCEL_TOKEN, deploymentId: id });
   let runtimeText = '';
-  try { runtimeText = await getRuntimeLogs({ token: VERCEL_TOKEN, projectId: VERCEL_PROJECT_ID, deploymentId: id }); } catch {}
+  try {
+    runtimeText = await getRuntimeLogs({ token: VERCEL_TOKEN, projectId: VERCEL_PROJECT_ID, deploymentId: id });
+  } catch (err) {
+    console.warn('Failed to fetch Vercel runtime logs:', err.message || err);
+  }
   const trimmedLogs = concatAndTrimLogs({ buildText, runtimeText });
   const issues = extractIssuesFromLogs(trimmedLogs);
   return { trimmedLogs, issues, deployments };


### PR DESCRIPTION
## Summary
- warn when Vercel runtime log fetching fails instead of swallowing error

## Testing
- `npm test` (fails: Missing script "test")
- `OPENAI_API_KEY=test VERCEL_TOKEN=invalid VERCEL_PROJECT_ID=foo TARGET_REPO_DIR=$PWD NODE_OPTIONS="--require /tmp/mock-fetch.cjs" node automation/ai-iter-agent.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689afc566518832aad239e77028103ea