### PR TITLE
feat: broaden agent changes per commit

### DIFF
--- a/automation/lib/prompt.cjs
+++ b/automation/lib/prompt.cjs
@@ -14,11 +14,11 @@ You are a code patch generator for an automation agent.
 - context: { packageManager, frameworkVariant }
 
 ## Goal
-Produce a SMALL, SAFE change that either:
-1) fixes an issue shown in logs, or
-2) implements ONE low-risk roadmap improvement (tiny feature) if there are no issues.
+Produce a MEANINGFUL yet SAFE change that either:
+1) fixes one or more issues shown in logs, or
+2) implements roadmap improvement(s) if there are no issues.
 
-Keep the “red thread” simple: one focused change, minimal surface area.
+Group related updates into a coherent commit. Broader changes across multiple files are allowed when they drive visible progress.
 
 ## ABSOLUTE OUTPUT RULES
 - First, output ONLY a raw unified git diff that \`git apply\` can apply.
@@ -38,13 +38,13 @@ Keep the “red thread” simple: one focused change, minimal surface area.
 - Don’t introduce external dependencies or change package.json.
 - Don’t rename/move files.
 - Don’t delete files unless logs clearly require it and the file exists.
-- Keep edits minimal: **one** focused fix/feature, small diff.
+- Ensure edits remain coherent and safe; larger diffs touching multiple files are acceptable.
 - If frameworkVariant is 'next-pages', do not add 'app/' router and vice versa.
 - Prefer TypeScript only where file is already TS; otherwise keep JS.
 
 ## TARGETS & PREFERENCES
 - Prefer fixing clear errors from logs.
-- If no issues, implement **one** tiny, low-risk improvement (e.g., add a minimal \`pages/api/healthz.js\` or small cache headers to an existing API).
+- If no issues, implement small but meaningful roadmap improvements, potentially spanning multiple files (e.g., add a minimal \`pages/api/healthz.js\` and related helpers).
 - Prefer editing files already shown in repoFiles. If adding, choose a location that exists in repoTree.
 
 ## KNOWN SAFE PATTERNS (only if they match repo state)


### PR DESCRIPTION
## Summary
- Allow prompt to request larger, multi-file updates
- Expand file selection and commit style for broader progress

## Testing
- `node automation/lib/parseLogs.test.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689b33f5ee40832aaa799bf4f5cb2bd9