### PR TITLE
Sanitize diffs by removing NEXT STEPS sections

### DIFF
--- a/automation/lib/utils.cjs
+++ b/automation/lib/utils.cjs
@@ -64,6 +64,10 @@ function sanitizeDiff(raw) {
     '\n# CHANGES SUMMARY',
     '\n#Changes Summary',
     '\n#CHANGES SUMMARY',
+    '\n# Next Steps',
+    '\n# NEXT STEPS',
+    '\n#Next Steps',
+    '\n#NEXT STEPS',
     '\n*** End Patch',
     '\n```'
   ];


### PR DESCRIPTION
## Summary
- strip NEXT STEPS sections in sanitizeDiff so follow-up guidance is removed before applying patches

## Testing
- `node automation/lib/parseLogs.test.cjs`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b39124acc832ab0ff3031aa8bb6f6