### PR TITLE
Handle numbered roadmap lists and preface text

### DIFF
--- a/automation/lib/updateRoadmap.test.cjs
+++ b/automation/lib/updateRoadmap.test.cjs
@@ -1,0 +1,29 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { updateRoadmap } = require('./utils.cjs');
+
+// Bullet list with preface text
+{
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-'));
+  const file = path.join(dir, 'roadmap.md');
+  fs.writeFileSync(file, '# Roadmap\n\n## Progress\nPreface line\n- existing\n', 'utf8');
+  updateRoadmap(dir, 'new item', '');
+  const content = fs.readFileSync(file, 'utf8');
+  assert.match(content, /## Progress\n\nPreface line\n- existing\n- new item\n/);
+}
+
+// Numbered list
+{
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-'));
+  const file = path.join(dir, 'roadmap.md');
+  fs.writeFileSync(file, '# Roadmap\n\n## Next Steps\n1. first\n2. second\n', 'utf8');
+  updateRoadmap(dir, '', 'third');
+  const content = fs.readFileSync(file, 'utf8');
+  assert.match(content, /## Next Steps\n\n1\. first\n2\. second\n- third\n/);
+}
+
+console.log('updateRoadmap tests passed.');

--- a/automation/lib/utils.cjs
+++ b/automation/lib/utils.cjs
@@ -446,6 +446,9 @@ function updateRoadmap(repoDir, changesSummary = '', nextSteps = '') {
       }
 
       let insert = idx + 2;
+      // Skip any non-list preface lines before the actual list items.
+      while (insert < sectionEnd && !isItem(lines[insert]) && lines[insert].trim() !== '') insert++;
+      // Then advance past existing list items (bulleted or numbered).
       while (insert < sectionEnd && isItem(lines[insert])) insert++;
 
       const entries = items.map((t) => `- ${t}`);


### PR DESCRIPTION
## Summary
- handle non-list preface text and numbered items when updating roadmap sections
- add tests for bullet and numeric list handling in roadmap updates

## Testing
- `node automation/lib/parseLogs.test.cjs`
- `node automation/lib/updateRoadmap.test.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689b757141c4832ab433e4bcc91a20af