### PR TITLE
chore: rely on actions concurrency

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -8,7 +8,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: agent-implement-${{ github.ref }}
+  group: ai-dev-agent-global
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/agent-ingest-logs.yml
+++ b/.github/workflows/agent-ingest-logs.yml
@@ -8,7 +8,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: agent-ingest-logs-${{ github.ref }}
+  group: ai-dev-agent-global
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/agent-review-repo.yml
+++ b/.github/workflows/agent-review-repo.yml
@@ -8,7 +8,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: agent-review-repo-${{ github.ref }}
+  group: ai-dev-agent-global
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/agent-synthesize-tasks.yml
+++ b/.github/workflows/agent-synthesize-tasks.yml
@@ -8,7 +8,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: agent-synthesize-tasks-${{ github.ref }}
+  group: ai-dev-agent-global
   cancel-in-progress: false
 
 jobs:

--- a/src/lib/lock.ts
+++ b/src/lib/lock.ts
@@ -1,19 +1,30 @@
 import { readFile, upsertFile } from "./github.js";
 
-const LOCK_PATH = "roadmap/.lock";
+type LockStrategy = "actions" | "file" | "none";
+const STRATEGY = (process.env.AI_LOCK_STRATEGY as LockStrategy) || "actions";
 
+/**
+ * When STRATEGY="actions" (default), rely on GitHub Actions concurrency.
+ * When STRATEGY="file", write a timestamp to a repo file (optional).
+ * When STRATEGY="none", always return true (not recommended in CI).
+ */
 export async function acquireLock(ttlSeconds = 900): Promise<boolean> {
+  if (STRATEGY !== "file") return true; // actions/none → no file commits
+  const LOCK_PATH = "roadmap/.state/lock"; // tucked away in .state
   const now = Date.now();
   const existing = await readFile(LOCK_PATH);
   if (existing) {
     const ts = Number(existing.trim());
     if (!Number.isNaN(ts) && now - ts < ttlSeconds * 1000) return false;
   }
-  await upsertFile(LOCK_PATH, () => String(now), "bot: acquire lock");
+  // Single commit on acquire; include [skip ci] to avoid triggering workflows in TARGET_REPO
+  await upsertFile(LOCK_PATH, () => String(now) + "\n", "[skip ci] bot: acquire lock");
   return true;
 }
 
-export async function releaseLock() {
-  // Overwrite with 0 rather than delete to avoid permissions edge cases
-  await upsertFile(LOCK_PATH, () => "0\n", "bot: release lock");
+export async function releaseLock(): Promise<void> {
+  // No-op to avoid a second "release lock" commit; TTL will expire it.
+  if (STRATEGY !== "file") return;
+  // (intentionally empty)
 }
+


### PR DESCRIPTION
## Summary
- use shared `ai-dev-agent-global` concurrency group in all workflows
- make lock a no-op unless `AI_LOCK_STRATEGY=file`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689d106d2808832a82f30bf3ee44a6a0