### PR TITLE
fix: sanitize file paths in implement step

### DIFF
--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -1,5 +1,5 @@
 import { acquireLock, releaseLock } from "../lib/lock.js";
-import { readFile, upsertFile, commitMany } from "../lib/github.js";
+import { readFile, upsertFile, commitMany, resolveRepoPath } from "../lib/github.js";
 import { readYamlBlock, writeYamlBlock } from "../lib/md.js";
 import { implementPlan } from "../lib/prompts.js";
 import { ENV } from "../lib/env.js";
@@ -26,10 +26,26 @@ export async function implementTopTask() {
     let plan: any = {};
     try { plan = JSON.parse(planJson); } catch { plan = {}; }
 
-    const ops: Array<{ path: string; action: string; content?: string }> = Array.isArray(plan.operations) ? plan.operations : [];
-    const filtered = ENV.ALLOW_PATHS.length
-      ? ops.filter(o => ENV.ALLOW_PATHS.some(allow => o.path.startsWith(allow)))
-      : ops;
+    const ops: Array<{ path: string; action: string; content?: string }> =
+      Array.isArray(plan.operations) ? plan.operations : [];
+
+    // Normalize to safe, repo-relative paths (and apply TARGET_DIR)
+    const normalized: Array<{ path: string; action: string; content?: string }> = [];
+    for (const o of ops) {
+      try {
+        normalized.push({ ...o, path: resolveRepoPath(o.path || "") });
+      } catch (err) {
+        console.warn(`Skipping operation with invalid path ${o.path}:`, err);
+      }
+    }
+
+    // Enforce ALLOW_PATHS after normalization (if configured)
+    let filtered = ENV.ALLOW_PATHS.length
+      ? normalized.filter(o => {
+          const allows = ENV.ALLOW_PATHS.map(a => a.replace(/^\/+/, "").replace(/^\.\//, ""));
+          return allows.some(allow => o.path.startsWith(allow));
+        })
+      : normalized;
 
     if (!filtered.length) {
       // Fallback: create a minimal test placeholder if none proposed

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,4 +1,5 @@
 import { Octokit } from "octokit";
+import { posix as pathPosix } from "node:path";
 import { ENV } from "./env.js";
 
 export type RepoRef = { owner: string; repo: string };
@@ -33,6 +34,18 @@ async function getFile(owner: string, repo: string, path: string) {
   }
 }
 
+export function resolveRepoPath(p: string): string {
+  if (!p) throw new Error("Empty path");
+  let norm = p.replace(/\\/g, "/").replace(/^\/+/, "").replace(/^\.\//, "");
+  norm = pathPosix.normalize(norm);
+  if (norm === "" || norm === "." || norm.startsWith("..")) {
+    throw new Error(`Refusing path outside repo: ${p}`);
+  }
+  const base = (ENV.TARGET_DIR || "").replace(/^\/+|\/+$/g, "");
+  const joined = base ? pathPosix.join(base, norm) : norm;
+  return joined.replace(/^\/+/, "");
+}
+
 export async function readFile(path: string): Promise<string | undefined> {
   const { owner, repo } = parseRepo(ENV.TARGET_REPO);
   const got = await getFile(owner, repo, path);
@@ -45,18 +58,19 @@ export async function upsertFile(
   message: string
 ) {
   const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+  const safePath = resolveRepoPath(path);
   if (ENV.DRY_RUN) {
-    const old = await readFile(path);
+    const old = await readFile(safePath);
     const next = updater(old);
-    console.log(`[DRY_RUN] Would write ${path} with message: ${message}\n---\n${next}`);
+    console.log(`[DRY_RUN] Would write ${safePath} with message: ${message}\n---\n${next}`);
     return;
   }
-  const { sha, content: old } = await getFile(owner, repo, path);
+  const { sha, content: old } = await getFile(owner, repo, safePath);
   const next = updater(old);
   await gh().rest.repos.createOrUpdateFileContents({
     owner,
     repo,
-    path,
+    path: safePath,
     message,
     content: b64(next),
     sha, // include if file existed
@@ -71,15 +85,16 @@ export async function commitMany(
 ) {
   const { owner, repo } = parseRepo(ENV.TARGET_REPO);
   if (ENV.DRY_RUN) {
-    console.log(`[DRY_RUN] Would commit ${files.length} files:`, files.map(f => f.path));
+    console.log(`[DRY_RUN] Would commit ${files.length} files:`, files.map(f => resolveRepoPath(f.path))); 
     return;
   }
   for (const f of files) {
-    const existing = await getFile(owner, repo, f.path);
+    const safePath = resolveRepoPath(f.path);
+    const existing = await getFile(owner, repo, safePath);
     await gh().rest.repos.createOrUpdateFileContents({
       owner,
       repo,
-      path: f.path,
+      path: safePath,
       message,
       content: b64(f.content),
       sha: existing.sha,


### PR DESCRIPTION
## Summary
- add resolveRepoPath utility to normalize and constrain file paths
- use resolveRepoPath in GitHub writers to ensure relative paths
- normalize implement operations and enforce allowlist after normalization

## Testing
- `npm run build`
- `TARGET_DIR="" ALLOW_PATHS="" TARGET_REPO="owner/repo" DRY_RUN=1 node dist/cli.js implement` *(fails: connect ENETUNREACH)*
- `TARGET_DIR="app" ALLOW_PATHS="" TARGET_REPO="owner/repo" DRY_RUN=1 node dist/cli.js implement` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689d80694514832ab5bdc7bec949ce1c