### PR TITLE
feat: commit roadmap and code updates together

### DIFF
--- a/dist/cmds/implement.js
+++ b/dist/cmds/implement.js
@@ -1,5 +1,5 @@
 import { acquireLock, releaseLock } from "../lib/lock.js";
-import { readFile, upsertFile, commitMany } from "../lib/github.js";
+import { readFile, commitMany } from "../lib/github.js";
 import { readYamlBlock, writeYamlBlock } from "../lib/md.js";
 import { implementPlan } from "../lib/prompts.js";
 import { ENV } from "../lib/env.js";
@@ -50,17 +50,23 @@ export async function implementTopTask() {
                 continue;
             files.push({ path: op.path, content: op.content ?? "" });
         }
+        // Prepare roadmap updates
+        const remaining = tYaml.items.filter(i => i !== top);
+        const nextTasks = writeYamlBlock(tRaw, { items: remaining });
+        files.push({ path: "roadmap/tasks.md", content: nextTasks });
+        const doneLine = `- ${new Date().toISOString()}: ✅ ${top.id || ""} — ${plan.commitTitle || top.title}\n`;
+        files.push({ path: "roadmap/done.md", content: done + doneLine });
         if (files.length) {
             const title = plan.commitTitle || ((top.type === "bug" ? "fix" : "feat") + `: ${top.title || top.id}`);
             const body = plan.commitBody || (top.desc || "");
-            await commitMany(files, `${title}\n\n${body}`);
+            try {
+                await commitMany(files, `${title}\n\n${body}`);
+            }
+            catch (err) {
+                console.error("Commit failed, rolling back", err);
+                return;
+            }
         }
-        // Update roadmap: remove task and append to done
-        const remaining = tYaml.items.filter(i => i !== top);
-        const nextTasks = writeYamlBlock(tRaw, { items: remaining });
-        await upsertFile("roadmap/tasks.md", () => nextTasks, "bot: remove completed task");
-        const doneLine = `- ${new Date().toISOString()}: ✅ ${top.id || ""} — ${plan.commitTitle || top.title}\n`;
-        await upsertFile("roadmap/done.md", (old) => (old || "") + doneLine, "bot: append done");
         console.log("Implement complete.");
     }
     finally {

--- a/dist/lib/github.js
+++ b/dist/lib/github.js
@@ -61,17 +61,38 @@ export async function commitMany(files, message) {
         console.log(`[DRY_RUN] Would commit ${files.length} files:`, files.map(f => f.path));
         return;
     }
-    for (const f of files) {
-        const existing = await getFile(owner, repo, f.path);
-        await gh().rest.repos.createOrUpdateFileContents({
+    const client = gh();
+    // Determine default branch and current commit
+    const { data: repoInfo } = await client.rest.repos.get({ owner, repo });
+    const branch = repoInfo.default_branch;
+    const { data: ref } = await client.rest.git.getRef({ owner, repo, ref: `heads/${branch}` });
+    const currentSha = ref.object.sha;
+    const { data: baseCommit } = await client.rest.git.getCommit({ owner, repo, commit_sha: currentSha });
+    try {
+        // Create blobs for each file
+        const treeEntries = await Promise.all(files.map(async (f) => {
+            const blob = await client.rest.git.createBlob({ owner, repo, content: f.content, encoding: "utf-8" });
+            return { path: f.path, mode: "100644", type: "blob", sha: blob.data.sha };
+        }));
+        // Build tree and commit
+        const { data: tree } = await client.rest.git.createTree({ owner, repo, base_tree: baseCommit.tree.sha, tree: treeEntries });
+        const { data: commit } = await client.rest.git.createCommit({
             owner,
             repo,
-            path: f.path,
             message,
-            content: b64(f.content),
-            sha: existing.sha,
-            committer: { name: "ai-dev-agent", email: "bot@local" },
-            author: { name: "ai-dev-agent", email: "bot@local" }
+            tree: tree.sha,
+            parents: [currentSha],
+            author: { name: "ai-dev-agent", email: "bot@local" },
+            committer: { name: "ai-dev-agent", email: "bot@local" }
         });
+        await client.rest.git.updateRef({ owner, repo, ref: `heads/${branch}`, sha: commit.sha });
+    }
+    catch (e) {
+        // Roll back to previous commit if something went wrong
+        try {
+            await client.rest.git.updateRef({ owner, repo, ref: `heads/${branch}`, sha: currentSha, force: true });
+        }
+        catch { }
+        throw e;
     }
 }

--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -1,5 +1,5 @@
 import { acquireLock, releaseLock } from "../lib/lock.js";
-import { readFile, upsertFile, commitMany } from "../lib/github.js";
+import { readFile, commitMany } from "../lib/github.js";
 import { readYamlBlock, writeYamlBlock } from "../lib/md.js";
 import { implementPlan } from "../lib/prompts.js";
 import { ENV } from "../lib/env.js";
@@ -46,19 +46,25 @@ export async function implementTopTask() {
       if (op.action !== "create" && op.action !== "update") continue;
       files.push({ path: op.path, content: op.content ?? "" });
     }
+
+    // Prepare roadmap updates
+    const remaining = tYaml.items.filter(i => i !== top);
+    const nextTasks = writeYamlBlock(tRaw, { items: remaining });
+    files.push({ path: "roadmap/tasks.md", content: nextTasks });
+
+    const doneLine = `- ${new Date().toISOString()}: ✅ ${top.id || ""} — ${plan.commitTitle || top.title}\n`;
+    files.push({ path: "roadmap/done.md", content: done + doneLine });
+
     if (files.length) {
       const title = plan.commitTitle || ((top.type === "bug" ? "fix" : "feat") + `: ${top.title || top.id}`);
       const body  = plan.commitBody || (top.desc || "");
-      await commitMany(files, `${title}\n\n${body}`);
+      try {
+        await commitMany(files, `${title}\n\n${body}`);
+      } catch (err) {
+        console.error("Commit failed, rolling back", err);
+        return;
+      }
     }
-
-    // Update roadmap: remove task and append to done
-    const remaining = tYaml.items.filter(i => i !== top);
-    const nextTasks = writeYamlBlock(tRaw, { items: remaining });
-    await upsertFile("roadmap/tasks.md", () => nextTasks, "bot: remove completed task");
-
-    const doneLine = `- ${new Date().toISOString()}: ✅ ${top.id || ""} — ${plan.commitTitle || top.title}\n`;
-    await upsertFile("roadmap/done.md", (old) => (old || "") + doneLine, "bot: append done");
 
     console.log("Implement complete.");
   } finally {


### PR DESCRIPTION
## Summary
- build `commitMany` to batch file updates into one commit using git trees and refs
- include `roadmap/tasks.md` and `roadmap/done.md` in implement command so code and roadmap change together
- add rollback handling when bulk commit fails

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d855d32cc832aa3c832a28dd1f786