### PR TITLE
feat: atomically commit multiple files

### DIFF
--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -1,5 +1,5 @@
 import { acquireLock, releaseLock } from "../lib/lock.js";
-import { readFile, upsertFile, commitMany, resolveRepoPath } from "../lib/github.js";
+import { readFile, commitMany, resolveRepoPath } from "../lib/github.js";
 import { readYamlBlock, writeYamlBlock } from "../lib/md.js";
 import { implementPlan } from "../lib/prompts.js";
 import { ENV } from "../lib/env.js";
@@ -56,27 +56,31 @@ export async function implementTopTask() {
       });
     }
 
-    // Apply operations
+    // Apply operations and roadmap updates
     const files: Array<{ path: string; content: string }> = [];
     for (const op of filtered) {
       if (op.action !== "create" && op.action !== "update") continue;
       files.push({ path: op.path, content: op.content ?? "" });
     }
+
+    // Prepare roadmap changes
+    const remaining = tYaml.items.filter(i => i !== top);
+    const nextTasks = writeYamlBlock(tRaw, { items: remaining });
+    const doneLine = `- ${new Date().toISOString()}: ✅ ${top.id || ""} — ${plan.commitTitle || top.title}\n`;
+    const nextDone = done + doneLine;
+    files.push({ path: "roadmap/tasks.md", content: nextTasks });
+    files.push({ path: "roadmap/done.md", content: nextDone });
+
     if (files.length) {
       const title = plan.commitTitle || ((top.type === "bug" ? "fix" : "feat") + `: ${top.title || top.id}`);
       const body  = plan.commitBody || (top.desc || "");
-      await commitMany(files, `${title}\n\n${body}`);
+      try {
+        await commitMany(files, `${title}\n\n${body}`);
+        console.log("Implement complete.");
+      } catch (err) {
+        console.error("Bulk commit failed; no changes were applied.", err);
+      }
     }
-
-    // Update roadmap: remove task and append to done
-    const remaining = tYaml.items.filter(i => i !== top);
-    const nextTasks = writeYamlBlock(tRaw, { items: remaining });
-    await upsertFile("roadmap/tasks.md", () => nextTasks, "bot: remove completed task");
-
-    const doneLine = `- ${new Date().toISOString()}: ✅ ${top.id || ""} — ${plan.commitTitle || top.title}\n`;
-    await upsertFile("roadmap/done.md", (old) => (old || "") + doneLine, "bot: append done");
-
-    console.log("Implement complete.");
   } finally {
     await releaseLock();
   }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -85,21 +85,51 @@ export async function commitMany(
 ) {
   const { owner, repo } = parseRepo(ENV.TARGET_REPO);
   if (ENV.DRY_RUN) {
-    console.log(`[DRY_RUN] Would commit ${files.length} files:`, files.map(f => resolveRepoPath(f.path))); 
+    console.log(
+      `[DRY_RUN] Would commit ${files.length} files:`,
+      files.map(f => resolveRepoPath(f.path))
+    );
     return;
   }
-  for (const f of files) {
-    const safePath = resolveRepoPath(f.path);
-    const existing = await getFile(owner, repo, safePath);
-    await gh().rest.repos.createOrUpdateFileContents({
-      owner,
-      repo,
-      path: safePath,
-      message,
-      content: b64(f.content),
-      sha: existing.sha,
-      committer: { name: "ai-dev-agent", email: "bot@local" },
-      author: { name: "ai-dev-agent", email: "bot@local" }
-    });
+
+  const client = gh();
+
+  // Normalize and ensure paths are within repo scope
+  const safe = files.map(f => ({ path: resolveRepoPath(f.path), content: f.content }));
+
+  // Determine the current branch and commit
+  const { data: repoData } = await client.rest.repos.get({ owner, repo });
+  const branch = repoData.default_branch;
+  const { data: refData } = await client.rest.git.getRef({ owner, repo, ref: `heads/${branch}` });
+  const baseSha = refData.object.sha;
+  const { data: commitData } = await client.rest.git.getCommit({ owner, repo, commit_sha: baseSha });
+
+  // Create blobs and collect tree entries
+  const tree: Array<{ path: string; mode: "100644"; type: "blob"; sha: string }> = [];
+  for (const f of safe) {
+    const blob = await client.rest.git.createBlob({ owner, repo, content: f.content, encoding: "utf-8" });
+    tree.push({ path: f.path, mode: "100644", type: "blob", sha: blob.data.sha });
+  }
+
+  // Create new tree and commit
+  const { data: newTree } = await client.rest.git.createTree({ owner, repo, base_tree: commitData.tree.sha, tree });
+  const { data: newCommit } = await client.rest.git.createCommit({
+    owner,
+    repo,
+    message,
+    tree: newTree.sha,
+    parents: [baseSha],
+    committer: { name: "ai-dev-agent", email: "bot@local" },
+    author: { name: "ai-dev-agent", email: "bot@local" }
+  });
+
+  // Update branch reference; rollback if it fails
+  try {
+    await client.rest.git.updateRef({ owner, repo, ref: `heads/${branch}`, sha: newCommit.sha });
+  } catch (err) {
+    try {
+      await client.rest.git.updateRef({ owner, repo, ref: `heads/${branch}`, sha: baseSha, force: true });
+    } catch {}
+    throw err;
   }
 }


### PR DESCRIPTION
## Summary
- Rewrite `commitMany` to build blobs, tree, and commit via Git API, rolling back on failure.
- Bundle roadmap updates with code operations so `implementTopTask` commits everything at once.

## Testing
- `npm run build`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689d86d84c24832a9803e7c75f2301af