### PR TITLE
feat: support branching commits

### DIFF
--- a/dist/cmds/implement.js
+++ b/dist/cmds/implement.js
@@ -75,7 +75,7 @@ export async function implementTopTask() {
             const title = plan.commitTitle || ((top.type === "bug" ? "fix" : "feat") + `: ${top.title || top.id}`);
             const body = plan.commitBody || (top.desc || "");
             try {
-                await commitMany(files, `${title}\n\n${body}`);
+                await commitMany(files, `${title}\n\n${body}`, ENV.BRANCH);
                 console.log("Implement complete.");
             }
             catch (err) {

--- a/dist/lib/env.js
+++ b/dist/lib/env.js
@@ -11,6 +11,7 @@ export const ENV = {
     OPENAI_MODEL: process.env.OPENAI_MODEL || "gpt-4o-mini",
     WRITE_MODE: process.env.AI_BOT_WRITE_MODE || "commit",
     DRY_RUN: process.env.DRY_RUN === "1",
+    BRANCH: process.env.GITHUB_REF_NAME || process.env.GITHUB_HEAD_REF || "",
     ALLOW_PATHS: (process.env.ALLOW_PATHS || "").split(",").map(s => s.trim()).filter(Boolean),
 };
 // Call this inside commands to assert only what they need.

--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -75,7 +75,7 @@ export async function implementTopTask() {
       const title = plan.commitTitle || ((top.type === "bug" ? "fix" : "feat") + `: ${top.title || top.id}`);
       const body  = plan.commitBody || (top.desc || "");
       try {
-        await commitMany(files, `${title}\n\n${body}`);
+        await commitMany(files, `${title}\n\n${body}`, ENV.BRANCH);
         console.log("Implement complete.");
       } catch (err) {
         console.error("Bulk commit failed; no changes were applied.", err);

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -11,6 +11,7 @@ export const ENV = {
   OPENAI_MODEL: process.env.OPENAI_MODEL || "gpt-4o-mini",
   WRITE_MODE: process.env.AI_BOT_WRITE_MODE || "commit",
   DRY_RUN: process.env.DRY_RUN === "1",
+  BRANCH: process.env.GITHUB_REF_NAME || process.env.GITHUB_HEAD_REF || "",
   ALLOW_PATHS: (process.env.ALLOW_PATHS || "").split(",").map(s => s.trim()).filter(Boolean),
 };
 


### PR DESCRIPTION
## Summary
- expose `ENV.BRANCH` from GitHub-provided env vars
- allow `commitMany` to work on provided branch
- use branch-aware commit logic in implement command

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d90026cbc832ab2bf91ed2ee1c429