### PR TITLE
Validate TARGET_DIR in resolveRepoPath

### DIFF
--- a/dist/lib/github.js
+++ b/dist/lib/github.js
@@ -38,7 +38,11 @@ export function resolveRepoPath(p) {
     if (norm === "" || norm === "." || norm.startsWith("..")) {
         throw new Error(`Refusing path outside repo: ${p}`);
     }
-    const base = (ENV.TARGET_DIR || "").replace(/^\/+|\/+$/g, "");
+    const rawBase = ENV.TARGET_DIR || "";
+    const base = rawBase.replace(/^\/+|\/+$/g, "");
+    if (base.includes("://") || base.includes(":")) {
+        throw new Error(`Invalid TARGET_DIR: ${ENV.TARGET_DIR}`);
+    }
     const joined = base ? pathPosix.join(base, norm) : norm;
     return joined.replace(/^\/+/, "");
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -41,7 +41,11 @@ export function resolveRepoPath(p: string): string {
   if (norm === "" || norm === "." || norm.startsWith("..")) {
     throw new Error(`Refusing path outside repo: ${p}`);
   }
-  const base = (ENV.TARGET_DIR || "").replace(/^\/+|\/+$/g, "");
+  const rawBase = ENV.TARGET_DIR || "";
+  const base = rawBase.replace(/^\/+|\/+$/g, "");
+  if (base.includes("://") || base.includes(":")) {
+    throw new Error(`Invalid TARGET_DIR: ${ENV.TARGET_DIR}`);
+  }
   const joined = base ? pathPosix.join(base, norm) : norm;
   return joined.replace(/^\/+/, "");
 }


### PR DESCRIPTION
## Summary
- Harden path resolution by validating `TARGET_DIR` for schemes or colons before joining
- Throw descriptive error on invalid `TARGET_DIR`
- Rebuild compiled JavaScript output

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689db26a9fc0832a9f30c75d51dbedeb