### PR TITLE
feat: review only new commits in review-repo command

### DIFF
--- a/dist/cmds/review-repo.js
+++ b/dist/cmds/review-repo.js
@@ -3,22 +3,33 @@ import { readFile, parseRepo, gh, upsertFile } from "../lib/github.js";
 import { readYamlBlock, writeYamlBlock } from "../lib/md.js";
 import { reviewToIdeas } from "../lib/prompts.js";
 import { loadState, saveState } from "../lib/state.js";
+import { requireEnv, ENV } from "../lib/env.js";
 export async function reviewRepo() {
     if (!(await acquireLock())) {
         console.log("Lock taken; exiting.");
         return;
     }
     try {
+        requireEnv(["TARGET_REPO"]);
         const vision = (await readFile("roadmap/vision.md")) || "";
         const tasks = (await readFile("roadmap/tasks.md")) || "";
         const bugs = (await readFile("roadmap/bugs.md")) || "";
         const done = (await readFile("roadmap/done.md")) || "";
         const fresh = (await readFile("roadmap/new.md")) || "";
         const state = await loadState();
-        const { owner, repo } = parseRepo(process.env.TARGET_REPO);
-        const commits = await gh().rest.repos.listCommits({ owner, repo, per_page: 10 });
-        const sinceSha = state.lastReviewedSha;
-        const recent = commits.data.map((c) => `${c.sha.slice(0, 7)} ${c.commit.message.split("\n")[0]}`);
+        const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+        const commitsResp = await gh().rest.repos.listCommits({ owner, repo, per_page: 10 });
+        const commitsData = [];
+        for (const c of commitsResp.data) {
+            if (c.sha === state.lastReviewedSha)
+                break;
+            commitsData.push(c);
+        }
+        if (commitsData.length === 0) {
+            console.log("No new commits to review.");
+            return;
+        }
+        const recent = commitsData.map((c) => `${c.sha.slice(0, 7)} ${c.commit.message.split("\n")[0]}`);
         const input = { commits: recent, vision, tasks, bugs, done, fresh };
         const ideas = await reviewToIdeas(input);
         const newPath = "roadmap/new.md";
@@ -27,7 +38,7 @@ export async function reviewRepo() {
         yaml.queue.push({ id: `IDEA-${Date.now()}`, title: "Architect review batch", details: ideas, created: new Date().toISOString() });
         const next = writeYamlBlock(current, yaml);
         await upsertFile(newPath, () => next, "bot: review repo → new.md");
-        const headSha = commits.data[0]?.sha;
+        const headSha = commitsData[0]?.sha;
         await saveState({ ...state, lastReviewedSha: headSha });
         console.log("Review complete.");
     }

--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -3,10 +3,12 @@ import { readFile, parseRepo, gh, upsertFile } from "../lib/github.js";
 import { readYamlBlock, writeYamlBlock } from "../lib/md.js";
 import { reviewToIdeas } from "../lib/prompts.js";
 import { loadState, saveState } from "../lib/state.js";
+import { requireEnv, ENV } from "../lib/env.js";
 
 export async function reviewRepo() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
+    requireEnv(["TARGET_REPO"]);
     const vision = (await readFile("roadmap/vision.md")) || "";
     const tasks  = (await readFile("roadmap/tasks.md"))  || "";
     const bugs   = (await readFile("roadmap/bugs.md"))   || "";
@@ -14,10 +16,15 @@ export async function reviewRepo() {
     const fresh  = (await readFile("roadmap/new.md"))    || "";
 
     const state = await loadState();
-    const { owner, repo } = parseRepo(process.env.TARGET_REPO!);
-    const commits = await gh().rest.repos.listCommits({ owner, repo, per_page: 10 });
-    const sinceSha = state.lastReviewedSha;
-   const recent = commits.data.map(
+    const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+    const commitsResp = await gh().rest.repos.listCommits({ owner, repo, per_page: 10 });
+    const commitsData = [] as { sha: string; commit: { message: string } }[];
+    for (const c of commitsResp.data) {
+      if (c.sha === state.lastReviewedSha) break;
+      commitsData.push(c);
+    }
+    if (commitsData.length === 0) { console.log("No new commits to review."); return; }
+    const recent = commitsData.map(
       (c: { sha: string; commit: { message: string } }) =>
         `${c.sha.slice(0,7)} ${c.commit.message.split("\n")[0]}`
     );
@@ -32,7 +39,7 @@ export async function reviewRepo() {
 
     await upsertFile(newPath, () => next, "bot: review repo → new.md");
 
-    const headSha = commits.data[0]?.sha;
+    const headSha = commitsData[0]?.sha;
     await saveState({ ...state, lastReviewedSha: headSha });
     console.log("Review complete.");
   } finally {


### PR DESCRIPTION
## Summary
- enforce `TARGET_REPO` env var before reviewing
- review only commits newer than the last processed SHA

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689de156d548832aa38253a734a4f263