### PR TITLE
fix: parse YAML with CRLF line endings

### DIFF
--- a/dist/lib/md.js
+++ b/dist/lib/md.js
@@ -1,5 +1,5 @@
 import yaml from "js-yaml";
-const YAML_BLOCK = /```yaml\n([\s\S]*?)\n```/m;
+const YAML_BLOCK = /```yaml\r?\n([\s\S]*?)\r?\n```/m;
 export function readYamlBlock(md, fallback) {
     const m = md.match(YAML_BLOCK);
     if (!m)

--- a/src/lib/md.ts
+++ b/src/lib/md.ts
@@ -1,6 +1,6 @@
 import yaml from "js-yaml";
 
-const YAML_BLOCK = /```yaml\n([\s\S]*?)\n```/m;
+const YAML_BLOCK = /```yaml\r?\n([\s\S]*?)\r?\n```/m;
 
 export function readYamlBlock<T = any>(md: string, fallback: T): T {
   const m = md.match(YAML_BLOCK);


### PR DESCRIPTION
## Summary
- handle `\r\n` line endings when extracting YAML blocks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689dfda031d8832a9e8d8ebf0e0f8bc6