### PR TITLE
fix: respect target dir when reading files

### DIFF
--- a/dist/lib/github.js
+++ b/dist/lib/github.js
@@ -48,7 +48,8 @@ export function resolveRepoPath(p) {
 }
 export async function readFile(path) {
     const { owner, repo } = parseRepo(ENV.TARGET_REPO);
-    const got = await getFile(owner, repo, path);
+    const safePath = resolveRepoPath(path);
+    const got = await getFile(owner, repo, safePath);
     return got.content;
 }
 export async function upsertFile(path, updater, message) {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -52,7 +52,8 @@ export function resolveRepoPath(p: string): string {
 
 export async function readFile(path: string): Promise<string | undefined> {
   const { owner, repo } = parseRepo(ENV.TARGET_REPO);
-  const got = await getFile(owner, repo, path);
+  const safePath = resolveRepoPath(path);
+  const got = await getFile(owner, repo, safePath);
   return got.content;
 }
 


### PR DESCRIPTION
## Summary
- ensure file reads honor TARGET_DIR by normalizing paths with `resolveRepoPath`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e002b32a0832aba2da1e197730ccc