### PR TITLE
fix: apply target dir when reading files

### DIFF
--- a/dist/lib/github.js
+++ b/dist/lib/github.js
@@ -48,14 +48,15 @@ export function resolveRepoPath(p) {
 }
 export async function readFile(path) {
     const { owner, repo } = parseRepo(ENV.TARGET_REPO);
-    const got = await getFile(owner, repo, path);
+    const safePath = resolveRepoPath(path);
+    const got = await getFile(owner, repo, safePath);
     return got.content;
 }
 export async function upsertFile(path, updater, message) {
     const { owner, repo } = parseRepo(ENV.TARGET_REPO);
     const safePath = resolveRepoPath(path);
     if (ENV.DRY_RUN) {
-        const old = await readFile(safePath);
+        const old = await readFile(path);
         const next = updater(old);
         console.log(`[DRY_RUN] Would write ${safePath} with message: ${message}\n---\n${next}`);
         return;

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -52,7 +52,8 @@ export function resolveRepoPath(p: string): string {
 
 export async function readFile(path: string): Promise<string | undefined> {
   const { owner, repo } = parseRepo(ENV.TARGET_REPO);
-  const got = await getFile(owner, repo, path);
+  const safePath = resolveRepoPath(path);
+  const got = await getFile(owner, repo, safePath);
   return got.content;
 }
 
@@ -64,7 +65,7 @@ export async function upsertFile(
   const { owner, repo } = parseRepo(ENV.TARGET_REPO);
   const safePath = resolveRepoPath(path);
   if (ENV.DRY_RUN) {
-    const old = await readFile(safePath);
+    const old = await readFile(path);
     const next = updater(old);
     console.log(`[DRY_RUN] Would write ${safePath} with message: ${message}\n---\n${next}`);
     return;


### PR DESCRIPTION
## Summary
- ensure GitHub `readFile` respects `TARGET_DIR` by resolving repository-relative paths
- avoid double path resolution in `upsertFile`'s dry-run branch

## Testing
- `npm run build`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689e067579bc832ab3e0c2ce40f3bfd6