### PR TITLE
Normalize roadmap tasks and skip meta entries

### DIFF
--- a/.github/workflows/agent-normalize-roadmap.yml
+++ b/.github/workflows/agent-normalize-roadmap.yml
@@ -1,0 +1,17 @@
+name: agent-normalize-roadmap
+on:
+  schedule: [{ cron: "22 3 * * *" }]
+  workflow_dispatch:
+jobs:
+  normalize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: npm ci --no-audit --no-fund
+      - run: npm run build
+      - run: node dist/cli.js normalize-roadmap
+        env:
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          TARGET_REPO: ${{ secrets.TARGET_REPO }}

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -2,6 +2,7 @@ import { ingestLogs } from "./cmds/ingest-logs.js";
 import { reviewRepo } from "./cmds/review-repo.js";
 import { synthesizeTasks } from "./cmds/synthesize-tasks.js";
 import { implementTopTask } from "./cmds/implement.js";
+import { normalizeRoadmap } from "./cmds/normalize-roadmap.js";
 const cmd = process.argv[2];
 (async () => {
     try {
@@ -13,8 +14,10 @@ const cmd = process.argv[2];
             await synthesizeTasks();
         else if (cmd === "implement")
             await implementTopTask();
+        else if (cmd === "normalize-roadmap")
+            await normalizeRoadmap();
         else {
-            console.error("Usage: cli <ingest-logs|review-repo|synthesize-tasks|implement>");
+            console.error("Usage: cli <ingest-logs|review-repo|synthesize-tasks|implement|normalize-roadmap>");
             process.exit(2);
         }
     }

--- a/dist/cmds/implement.js
+++ b/dist/cmds/implement.js
@@ -1,8 +1,27 @@
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { readFile, commitMany, resolveRepoPath } from "../lib/github.js";
+import yaml from "js-yaml";
 import { readYamlBlock, writeYamlBlock } from "../lib/md.js";
 import { implementPlan } from "../lib/prompts.js";
 import { ENV } from "../lib/env.js";
+function extractTasks(md) {
+    const a = readYamlBlock(md, { items: [] });
+    if (a.items?.length)
+        return a.items;
+    const m = md.match(/```yaml\s*?\n([\s\S]*?)\n```/);
+    if (m) {
+        try {
+            const parsed = yaml.load(m[1]);
+            if (parsed?.items?.length)
+                return parsed.items;
+        }
+        catch { }
+    }
+    return [];
+}
+function isMeta(t) {
+    return /batch task synthesis/i.test(t?.title || "") || /```/.test(t?.desc || "");
+}
 export async function implementTopTask() {
     if (!(await acquireLock())) {
         console.log("Lock taken; exiting.");
@@ -13,14 +32,14 @@ export async function implementTopTask() {
         const vision = (await readFile("roadmap/vision.md")) || "";
         const done = (await readFile("roadmap/done.md")) || "";
         const tRaw = (await readFile("roadmap/tasks.md")) || "";
-        const tYaml = readYamlBlock(tRaw, { items: [] });
-        if (!tYaml.items.length) {
-            console.log("No tasks.");
+        const tasks = extractTasks(tRaw).filter(t => !isMeta(t));
+        if (!tasks.length) {
+            console.log("No tasks (none after filtering). Ensure tasks.md has one fenced yaml block with `items:`.");
             return;
         }
         // Pick highest priority
-        const tasks = [...tYaml.items].sort((a, b) => (a.priority || 999) - (b.priority || 999));
-        const top = tasks[0];
+        const sorted = [...tasks].sort((a, b) => (a.priority ?? 999) - (b.priority ?? 999));
+        const top = sorted[0];
         // Optional path guard
         const repoTree = []; // (keep empty for now, or list via GH if you want)
         const planJson = await implementPlan({ vision, done, topTask: top, repoTree });
@@ -65,7 +84,7 @@ export async function implementTopTask() {
             files.push({ path: op.path, content: op.content ?? "" });
         }
         // Prepare roadmap changes
-        const remaining = tYaml.items.filter(i => i !== top);
+        const remaining = tasks.filter(i => i !== top);
         const nextTasks = writeYamlBlock(tRaw, { items: remaining });
         const doneLine = `- ${new Date().toISOString()}: ✅ ${top.id || ""} — ${plan.commitTitle || top.title}\n`;
         const nextDone = done + doneLine;

--- a/dist/cmds/normalize-roadmap.js
+++ b/dist/cmds/normalize-roadmap.js
@@ -1,7 +1,5 @@
-// src/cmds/normalize-roadmap.ts
 import yaml from "js-yaml";
 import { acquireLock, releaseLock } from "../lib/lock.js";
-import { requireEnv } from "../lib/env.js";
 import { readFile, upsertFile } from "../lib/github.js";
 function normTitle(t = "") {
     return t.toLowerCase().replace(/\s+/g, " ").replace(/[`"'*]/g, "").trim();
@@ -9,26 +7,23 @@ function normTitle(t = "") {
 function yamlBlock(obj) {
     return "```yaml\n" + yaml.dump(obj, { lineWidth: 120 }) + "```";
 }
-function extractItems(md) {
+function extractAllItems(md) {
     const blocks = [...md.matchAll(/```yaml\s*?\n([\s\S]*?)\n```/g)];
-    const items = [];
+    const out = [];
     for (const m of blocks) {
         try {
             const parsed = yaml.load(m[1]);
             if (parsed && Array.isArray(parsed.items))
-                items.push(...parsed.items);
-            if (parsed && Array.isArray(parsed.queue)) {
-                // ignore queues (ideas/bugs) in tasks.md if they slipped in
-            }
+                out.push(...parsed.items);
         }
-        catch {
-            /* ignore */
-        }
+        catch { /* ignore */ }
     }
-    return items;
+    return out;
+}
+function isMeta(t) {
+    return /batch task synthesis/i.test(t?.title || "") || /```/.test(t?.desc || "");
 }
 export async function normalizeRoadmap() {
-    requireEnv(["PAT_TOKEN", "TARGET_REPO"]);
     if (!(await acquireLock())) {
         console.log("Lock taken; exiting.");
         return;
@@ -36,23 +31,21 @@ export async function normalizeRoadmap() {
     try {
         const path = "roadmap/tasks.md";
         const raw = (await readFile(path)) || "# Tasks (single source of truth)\n\n```yaml\nitems: []\n```";
-        let items = extractItems(raw);
-        // Drop synthetic/meta entries that contain YAML or "Batch task synthesis"
-        items = items.filter(t => t && t.title &&
-            !/batch task synthesis/i.test(t.title) &&
-            !(t.desc && /```yaml/.test(t.desc)));
-        // Dedupe by id (if present) else by (type + normalized title)
+        let items = extractAllItems(raw);
+        // Drop synthetic/meta tasks
+        items = items.filter(t => t?.title && !isMeta(t));
+        // Dedupe by id else (type+title)
         const seen = new Set();
         const deduped = [];
         for (const t of items) {
-            const key = (t.id?.toLowerCase()?.trim() && `id:${t.id.toLowerCase().trim()}`) ||
+            const key = (t.id && `id:${t.id.toLowerCase().trim()}`) ||
                 `tt:${(t.type || "").toLowerCase()}|${normTitle(t.title)}`;
             if (seen.has(key))
                 continue;
             seen.add(key);
             deduped.push(t);
         }
-        // Sort by existing priority, then created timestamp, then title
+        // Sort & assign unique priorities (cap 100)
         deduped.sort((a, b) => {
             const pa = a.priority ?? 1e9, pb = b.priority ?? 1e9;
             if (pa !== pb)
@@ -62,12 +55,11 @@ export async function normalizeRoadmap() {
                 return ca.localeCompare(cb);
             return normTitle(a.title).localeCompare(normTitle(b.title));
         });
-        // Reassign unique priorities 1..N and cap at 100
         const limited = deduped.slice(0, 100).map((t, i) => ({ ...t, priority: i + 1 }));
         const header = "# Tasks (single source of truth)\n\n";
         const next = header + yamlBlock({ items: limited }) + "\n";
-        await upsertFile(path, () => next, "bot: normalize tasks (dedupe + unique priorities)");
-        console.log(`Normalized tasks.md — kept ${limited.length} items with unique priorities.`);
+        await upsertFile(path, () => next, "bot: normalize tasks (single block, dedupe, unique priorities)");
+        console.log(`Normalized tasks.md — kept ${limited.length} items.`);
     }
     finally {
         await releaseLock();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@ import { ingestLogs } from "./cmds/ingest-logs.js";
 import { reviewRepo } from "./cmds/review-repo.js";
 import { synthesizeTasks } from "./cmds/synthesize-tasks.js";
 import { implementTopTask } from "./cmds/implement.js";
+import { normalizeRoadmap } from "./cmds/normalize-roadmap.js";
 
 const cmd = process.argv[2];
 
@@ -11,8 +12,9 @@ const cmd = process.argv[2];
     else if (cmd === "review-repo") await reviewRepo();
     else if (cmd === "synthesize-tasks") await synthesizeTasks();
     else if (cmd === "implement") await implementTopTask();
+    else if (cmd === "normalize-roadmap") await normalizeRoadmap();
     else {
-      console.error("Usage: cli <ingest-logs|review-repo|synthesize-tasks|implement>");
+      console.error("Usage: cli <ingest-logs|review-repo|synthesize-tasks|implement|normalize-roadmap>");
       process.exit(2);
     }
   } catch (err: any) {

--- a/src/cmds/normalize-roadmap.ts
+++ b/src/cmds/normalize-roadmap.ts
@@ -1,7 +1,5 @@
-// src/cmds/normalize-roadmap.ts
 import yaml from "js-yaml";
 import { acquireLock, releaseLock } from "../lib/lock.js";
-import { requireEnv } from "../lib/env.js";
 import { readFile, upsertFile } from "../lib/github.js";
 
 type Task = {
@@ -14,75 +12,64 @@ type Task = {
   priority?: number;
 };
 
-function normTitle(t: string = "") {
+function normTitle(t = "") {
   return t.toLowerCase().replace(/\s+/g, " ").replace(/[`"'*]/g, "").trim();
 }
-
 function yamlBlock(obj: any) {
   return "```yaml\n" + yaml.dump(obj, { lineWidth: 120 }) + "```";
 }
-
-function extractItems(md: string): Task[] {
+function extractAllItems(md: string): Task[] {
   const blocks = [...md.matchAll(/```yaml\s*?\n([\s\S]*?)\n```/g)];
-  const items: Task[] = [];
+  const out: Task[] = [];
   for (const m of blocks) {
     try {
       const parsed = yaml.load(m[1]) as any;
-      if (parsed && Array.isArray(parsed.items)) items.push(...parsed.items);
-      if (parsed && Array.isArray(parsed.queue)) {
-        // ignore queues (ideas/bugs) in tasks.md if they slipped in
-      }
-    } catch {
-      /* ignore */
-    }
+      if (parsed && Array.isArray(parsed.items)) out.push(...parsed.items);
+    } catch { /* ignore */ }
   }
-  return items;
+  return out;
+}
+function isMeta(t: Task) {
+  return /batch task synthesis/i.test(t?.title || "") || /```/.test(t?.desc || "");
 }
 
 export async function normalizeRoadmap() {
-    requireEnv(["PAT_TOKEN", "TARGET_REPO"]);
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
     const path = "roadmap/tasks.md";
     const raw = (await readFile(path)) || "# Tasks (single source of truth)\n\n```yaml\nitems: []\n```";
-    let items = extractItems(raw);
+    let items = extractAllItems(raw);
 
-    // Drop synthetic/meta entries that contain YAML or "Batch task synthesis"
-    items = items.filter(t =>
-      t && t.title &&
-      !/batch task synthesis/i.test(t.title) &&
-      !(t.desc && /```yaml/.test(t.desc))
-    );
+    // Drop synthetic/meta tasks
+    items = items.filter(t => t?.title && !isMeta(t));
 
-    // Dedupe by id (if present) else by (type + normalized title)
+    // Dedupe by id else (type+title)
     const seen = new Set<string>();
     const deduped: Task[] = [];
     for (const t of items) {
-      const key = (t.id?.toLowerCase()?.trim() && `id:${t.id.toLowerCase().trim()}`) ||
-                  `tt:${(t.type||"").toLowerCase()}|${normTitle(t.title)}`;
+      const key = (t.id && `id:${t.id.toLowerCase().trim()}`) ||
+                  `tt:${(t.type||"").toLowerCase()}|${normTitle(t.title!)}`;
       if (seen.has(key)) continue;
       seen.add(key);
       deduped.push(t);
     }
 
-    // Sort by existing priority, then created timestamp, then title
+    // Sort & assign unique priorities (cap 100)
     deduped.sort((a, b) => {
       const pa = a.priority ?? 1e9, pb = b.priority ?? 1e9;
       if (pa !== pb) return pa - pb;
       const ca = a.created || "", cb = b.created || "";
       if (ca !== cb) return ca.localeCompare(cb);
-      return normTitle(a.title).localeCompare(normTitle(b.title));
+      return normTitle(a.title!).localeCompare(normTitle(b.title!));
     });
-
-   // Reassign unique priorities 1..N and cap at 100
-   const limited = deduped.slice(0, 100).map((t, i) => ({ ...t, priority: i + 1 }));
+    const limited = deduped.slice(0, 100).map((t, i) => ({ ...t, priority: i + 1 }));
 
     const header = "# Tasks (single source of truth)\n\n";
     const next = header + yamlBlock({ items: limited }) + "\n";
-
-    await upsertFile(path, () => next, "bot: normalize tasks (dedupe + unique priorities)");
-    console.log(`Normalized tasks.md — kept ${limited.length} items with unique priorities.`);
+    await upsertFile(path, () => next, "bot: normalize tasks (single block, dedupe, unique priorities)");
+    console.log(`Normalized tasks.md — kept ${limited.length} items.`);
   } finally {
     await releaseLock();
   }
 }
+

--- a/src/cmds/synthesize-tasks.ts
+++ b/src/cmds/synthesize-tasks.ts
@@ -1,43 +1,64 @@
+import yaml from "js-yaml";
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { readFile, upsertFile } from "../lib/github.js";
-import { readYamlBlock, writeYamlBlock } from "../lib/md.js";
+import { readYamlBlock } from "../lib/md.js";
 import { synthesizeTasksPrompt } from "../lib/prompts.js";
+
+type Task = { id?: string; type?: string; title?: string; desc?: string; source?: string; created?: string; priority?: number };
+
+function normTitle(t = "") { return t.toLowerCase().replace(/\s+/g, " ").replace(/[`"'*]/g, "").trim(); }
+function yamlBlock(obj: any) { return "```yaml\n" + yaml.dump(obj, { lineWidth: 120 }) + "```"; }
+function isMeta(t: Task) { return /batch task synthesis/i.test(t?.title || "") || /```/.test(t?.desc || ""); }
 
 export async function synthesizeTasks() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
     const vision = (await readFile("roadmap/vision.md")) || "";
-    const tasks  = (await readFile("roadmap/tasks.md"))  || "";
-    const bugs   = (await readFile("roadmap/bugs.md"))   || "";
-    const ideas  = (await readFile("roadmap/new.md"))    || "";
-    const done   = (await readFile("roadmap/done.md"))   || "";
+    const tasksMd = (await readFile("roadmap/tasks.md")) || "";
+    const bugsMd  = (await readFile("roadmap/bugs.md"))  || "";
+    const ideasMd = (await readFile("roadmap/new.md"))   || "";
+    const doneMd  = (await readFile("roadmap/done.md"))  || "";
 
-    const proposal = await synthesizeTasksPrompt({ tasks, bugs, ideas, vision, done });
-    // naive: append proposal into tasks and clear queues (agent-friendly; you can refine)
-    const tYaml = readYamlBlock<any>(tasks, { items: [] });
-    const nYaml = readYamlBlock<any>(ideas, { queue: [] });
-    const bYaml = readYamlBlock<any>(bugs, { queue: [] });
+    const proposal = await synthesizeTasksPrompt({ tasks: tasksMd, bugs: bugsMd, ideas: ideasMd, vision, done: doneMd });
 
-    tYaml.items = Array.isArray(tYaml.items) ? tYaml.items : [];
-    tYaml.items = tYaml.items.slice(0, 100); // guardrail
+    // Extract YAML (fenced or bare)
+    const m = proposal.match(/```yaml\s*?\n([\s\S]*?)\n```/);
+    const toParse = m ? m[1] : proposal;
+    let parsed: any = {};
+    try { parsed = yaml.load(toParse) || {}; } catch { parsed = {}; }
+    let proposed: Task[] = Array.isArray(parsed.items) ? parsed.items : [];
+    proposed = proposed.filter(t => t?.title && !isMeta(t));
 
-    // Record the LLM proposal for traceability
-    tYaml.items.push({
-      id: `TSK-${Date.now()}`,
-      type: "improvement",
-      title: "Batch task synthesis",
-      desc: proposal,
-      source: "review",
-      created: new Date().toISOString(),
-      priority: (tYaml.items.length || 0) + 1
+    // Existing tasks
+    const existing = readYamlBlock<{ items: Task[] }>(tasksMd, { items: [] }).items || [];
+
+    // Merge & dedupe
+    const seen = new Set<string>();
+    const merged: Task[] = [];
+    for (const t of [...existing, ...proposed]) {
+      const key = (t.id && `id:${t.id.toLowerCase().trim()}`) ||
+                  `tt:${(t.type||"").toLowerCase()}|${normTitle(t.title!)}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      merged.push(t);
+    }
+
+    // Unique priorities 1..N (≤100)
+    merged.sort((a, b) => {
+      const pa = a.priority ?? 1e9, pb = b.priority ?? 1e9;
+      if (pa !== pb) return pa - pb;
+      const ca = a.created || "", cb = b.created || "";
+      if (ca !== cb) return ca.localeCompare(cb);
+      return normTitle(a.title!).localeCompare(normTitle(b.title!));
     });
+    const limited = merged.slice(0, 100).map((t, i) => ({ ...t, priority: i + 1 }));
 
-    await upsertFile("roadmap/tasks.md", (old) => writeYamlBlock(old, tYaml), "bot: synthesize → tasks.md");
-    await upsertFile("roadmap/new.md",   (old) => writeYamlBlock("", { queue: [] }), "bot: clear → new.md");
-    await upsertFile("roadmap/bugs.md",  (old) => writeYamlBlock("", { queue: [] }), "bot: clear → bugs.md");
-
-    console.log("Synthesis complete.");
+    const header = "# Tasks (single source of truth)\n\n";
+    const next = header + yamlBlock({ items: limited }) + "\n";
+    await upsertFile("roadmap/tasks.md", () => next, "bot: synthesize tasks (merge + dedupe + single block)");
+    console.log(`Synthesis complete. Tasks: ${limited.length}`);
   } finally {
     await releaseLock();
   }
 }
+


### PR DESCRIPTION
## Summary
- ensure roadmap/tasks.md is always a single YAML block with deduped priorities
- merge synthesized tasks into existing list without meta items
- harden task implementation flow against embedded YAML and add normalize-roadmap CLI command
- nightly workflow keeps roadmap/tasks.md normalized

## Testing
- `npm run build`
- `PAT_TOKEN=placeholder TARGET_REPO=foo/bar node dist/cli.js normalize-roadmap` *(fails: connect ENETUNREACH 140.82.112.6:443 - Local (0.0.0.0:0))*
- `PAT_TOKEN=placeholder TARGET_REPO=foo/bar OPENAI_API_KEY=placeholder node dist/cli.js implement` *(fails: connect ENETUNREACH 140.82.112.6:443 - Local (0.0.0.0:0))*

------
https://chatgpt.com/codex/tasks/task_e_689e0a6eaad8832a8852260e43229672