### PR TITLE
chore: add safeguard for roadmap vision

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Prevent commits that modify roadmap/vision.md
+if git diff --cached --name-only | grep -q '^roadmap/vision.md$'; then
+  echo 'Error: roadmap/vision.md is protected and cannot be modified.'
+  exit 1
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Guidelines
+
+- Do not create, edit, or delete `roadmap/vision.md`.
+- A pre-commit hook in `.githooks/pre-commit` prevents commits that modify this file. Ensure your local `core.hooksPath` is set to `.githooks` so the hook runs.
+- Run `npm test` and `npm run check` before submitting changes.


### PR DESCRIPTION
## Summary
- add pre-commit hook to block changes to `roadmap/vision.md`
- document the restriction and check commands in `AGENTS.md`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689e1454db38832aa10ba5383b4312a5