### PR TITLE
Use roadmap ideas queue for task synthesis

### DIFF
--- a/dist/lib/prompts.js
+++ b/dist/lib/prompts.js
@@ -49,7 +49,7 @@ export async function reviewToIdeas(input) {
     return r.choices[0]?.message?.content ?? "";
 }
 /**
- * Promote bugs/new → tasks with unique priorities (1..N).
+ * Promote items from roadmap/new.md (ideas queue) → tasks with unique priorities (1..N).
  * Return YAML (items: [...]) in a code block; caller merges & enforces limits.
  */
 export async function synthesizeTasksPrompt(input) {
@@ -57,7 +57,7 @@ export async function synthesizeTasksPrompt(input) {
     const messages = [
         {
             role: "system",
-            content: "Promote items from bugs/new into tasks.\n" +
+            content: "Promote items from roadmap/new.md (ideas queue) into tasks.\n" +
                 "Return ONLY YAML in a code block with the shape:\n```yaml\nitems:\n  - id: <leave blank or omit>\n    type: bug|improvement|feature\n    title: <short>\n    desc: <2–4 lines>\n    source: logs|review|user|vision\n    created: <ISO>\n    priority: <int>\n```\n" +
                 "Rules: no duplicates vs existing tasks; unique priorities 1..N; prefer critical bugs and user-impactful work; cap at ~100."
         },

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -70,7 +70,7 @@ export async function reviewToIdeas(input: {
 }
 
 /**
- * Promote bugs/new → tasks with unique priorities (1..N).
+ * Promote items from roadmap/new.md (ideas queue) → tasks with unique priorities (1..N).
  * Return YAML (items: [...]) in a code block; caller merges & enforces limits.
  */
 export async function synthesizeTasksPrompt(input: {
@@ -85,7 +85,7 @@ export async function synthesizeTasksPrompt(input: {
     {
       role: "system" as const,
       content:
-        "Promote items from bugs/new into tasks.\n" +
+        "Promote items from roadmap/new.md (ideas queue) into tasks.\n" +
         "Return ONLY YAML in a code block with the shape:\n```yaml\nitems:\n  - id: <leave blank or omit>\n    type: bug|improvement|feature\n    title: <short>\n    desc: <2–4 lines>\n    source: logs|review|user|vision\n    created: <ISO>\n    priority: <int>\n```\n" +
         "Rules: no duplicates vs existing tasks; unique priorities 1..N; prefer critical bugs and user-impactful work; cap at ~100."
     },


### PR DESCRIPTION
## Summary
- Update task synthesizer comment and prompt to promote items from `roadmap/new.md` rather than `bugs/new`.
- Regenerate compiled output.

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `npm run check`
- `npm run cmd:synthesize-tasks` *(fails: HttpError: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689e3fff6138832ab827f921aa6d7e86