### PR TITLE
fix: clear roadmap ideas after task synthesis

### DIFF
--- a/dist/cmds/synthesize-tasks.js
+++ b/dist/cmds/synthesize-tasks.js
@@ -57,6 +57,8 @@ export async function synthesizeTasks() {
         const header = "# Tasks (single source of truth)\n\n";
         const next = header + yamlBlock({ items: limited }) + "\n";
         await upsertFile("roadmap/tasks.md", () => next, "bot: synthesize tasks (merge + dedupe + single block)");
+        // Clear the ideas queue after merging so items aren't reprocessed
+        await upsertFile("roadmap/new.md", () => "", "bot: clear new.md after task synthesis");
         console.log(`Synthesis complete. Tasks: ${limited.length}`);
     }
     finally {

--- a/src/cmds/synthesize-tasks.ts
+++ b/src/cmds/synthesize-tasks.ts
@@ -55,7 +55,15 @@ export async function synthesizeTasks() {
 
     const header = "# Tasks (single source of truth)\n\n";
     const next = header + yamlBlock({ items: limited }) + "\n";
-    await upsertFile("roadmap/tasks.md", () => next, "bot: synthesize tasks (merge + dedupe + single block)");
+    await upsertFile(
+      "roadmap/tasks.md",
+      () => next,
+      "bot: synthesize tasks (merge + dedupe + single block)"
+    );
+
+    // Clear the ideas queue after merging so items aren't reprocessed
+    await upsertFile("roadmap/new.md", () => "", "bot: clear new.md after task synthesis");
+
     console.log(`Synthesis complete. Tasks: ${limited.length}`);
   } finally {
     await releaseLock();


### PR DESCRIPTION
## Summary
- clear roadmap/new.md after synthesizing tasks
- prevent repeated processing of identical ideas

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689e517ed760832abb684ec4fd45dbf1