### PR TITLE
feat: make review action structure-aware and target-agnostic

### DIFF
--- a/.github/workflows/agent-review-repo.yml
+++ b/.github/workflows/agent-review-repo.yml
@@ -33,9 +33,16 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: gpt-5
-          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
           TARGET_PATH: target
           MAX_FILES: 800
           MAX_BYTES_PER_FILE: 50000
           MAX_TASKS_PER_RUN: 5
           PROTECTED_PATHS: '["roadmap/vision.md","vision.md"]'
+      - name: Commit roadmap & audits to target
+        working-directory: target
+        run: |
+          git config user.name "ai-dev-agent"
+          git config user.email "ai@bot"
+          git add audits/*.md roadmap/*.md 2>/dev/null || true
+          git commit -m "chore(agent): repo review + tasks" || echo "nothing to commit"
+          git push

--- a/.github/workflows/agent-review-repo.yml
+++ b/.github/workflows/agent-review-repo.yml
@@ -31,7 +31,9 @@ jobs:
             npm install --package-lock-only --no-audit --no-fund
           fi
       - run: npm ci --no-audit --no-fund
-      - run: npx ts-node automation/review-repo.ts
+      - run: >-
+          npx tsc automation/prompt.ts automation/review-repo.ts --outDir dist/automation --rootDir automation --module NodeNext --moduleResolution NodeNext --target ES2022 --esModuleInterop --skipLibCheck
+      - run: node dist/automation/review-repo.js
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: gpt-5

--- a/.github/workflows/agent-review-repo.yml
+++ b/.github/workflows/agent-review-repo.yml
@@ -16,6 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ secrets.TARGET_REPO }}
+          token: ${{ secrets.PAT_TOKEN }}
+          path: target
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
       - name: Ensure lockfile (first run)
@@ -24,18 +29,13 @@ jobs:
             npm install --package-lock-only --no-audit --no-fund
           fi
       - run: npm ci --no-audit --no-fund
-      - run: npm run build
-      - run: node dist/cli.js review-repo
+      - run: npx ts-node automation/review-repo.ts
         env:
-          GH_USERNAME: ${{ secrets.GH_USERNAME }}
-          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-          TARGET_REPO: ${{ secrets.TARGET_REPO }}
-          TARGET_DIR: ${{ secrets.TARGET_DIR }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: gpt-5
-          AI_BOT_WRITE_MODE: commit
-          DRY_RUN: "0"
-          ALLOW_PATHS: ""
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          TARGET_PATH: target
+          MAX_FILES: 800
+          MAX_BYTES_PER_FILE: 50000
+          MAX_TASKS_PER_RUN: 5
+          PROTECTED_PATHS: '["roadmap/vision.md","vision.md"]'

--- a/.github/workflows/agent-review-repo.yml
+++ b/.github/workflows/agent-review-repo.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/checkout@v4
         with:
           repository: ${{ secrets.TARGET_REPO }}

--- a/.github/workflows/agent-review-repo.yml
+++ b/.github/workflows/agent-review-repo.yml
@@ -33,6 +33,7 @@ jobs:
           fi
       - run: npm ci --no-audit --no-fund
       - run: npm run build
+      # Run the compiled review script as the single entry point
       - run: node dist/automation/review-repo.js
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/agent-review-repo.yml
+++ b/.github/workflows/agent-review-repo.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 1
       - uses: actions/checkout@v4
         with:
           repository: ${{ secrets.TARGET_REPO }}
@@ -31,8 +32,7 @@ jobs:
             npm install --package-lock-only --no-audit --no-fund
           fi
       - run: npm ci --no-audit --no-fund
-      - run: >-
-          npx tsc automation/prompt.ts automation/review-repo.ts --outDir dist/automation --rootDir automation --module NodeNext --moduleResolution NodeNext --target ES2022 --esModuleInterop --skipLibCheck
+      - run: npm run build
       - run: node dist/automation/review-repo.js
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/automation/prompt.ts
+++ b/automation/prompt.ts
@@ -1,0 +1,44 @@
+import OpenAI from "openai";
+
+function requireEnv(names: string[]): void {
+  for (const n of names) {
+    if (!process.env[n]) {
+      throw new Error(`Missing env: ${n}`);
+    }
+  }
+}
+
+export async function planRepo(input: {
+  manifest: any;
+  roadmap: { tasks: string; fresh: string };
+  maxTasks: number;
+  protected: string[];
+}): Promise<string> {
+  requireEnv(["OPENAI_API_KEY", "OPENAI_MODEL"]);
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+  const system = [
+    "You are an agnostic, milestone-driven project planner.",
+    "Use only neutral terms (entities, records, admin area, REST endpoints).",
+    `Do not suggest changes in protected paths: ${input.protected.join(", ")}.`,
+    `Output sections in markdown with exact headings: \n` +
+      "REPO_SUMMARY\n" +
+      "STRUCTURE_FINDINGS\n" +
+      "TOP_MILESTONE\n" +
+      "TASKS\n" +
+      "DONE_UPDATES",
+    "STRUCTURE_FINDINGS must contain 3-7 bullets.",
+    "TOP_MILESTONE is one of: Foundation, CRUD Admin, Public API, Dashboard, Import/Export, Auth, Polish.",
+    `TASKS: cap at ${input.maxTasks}. Each task must have Title, Rationale, Acceptance, Files, Tests.`,
+    "Reject micro-tasks unless they unblock the milestone."
+  ].join("\n");
+
+  const user = JSON.stringify({ manifest: input.manifest, roadmap: input.roadmap });
+  const r = await openai.chat.completions.create({
+    model: process.env.OPENAI_MODEL!,
+    messages: [
+      { role: "system", content: system },
+      { role: "user", content: user }
+    ]
+  });
+  return r.choices[0]?.message?.content || "";
+}

--- a/automation/prompt.ts
+++ b/automation/prompt.ts
@@ -10,7 +10,7 @@ function requireEnv(names: string[]): void {
 
 export async function planRepo(input: {
   manifest: any;
-  roadmap: { tasks: string; fresh: string };
+  roadmap: { tasks: string; fresh: string; vision: string };
   maxTasks: number;
   protected: string[];
 }): Promise<string> {

--- a/automation/prompt.ts
+++ b/automation/prompt.ts
@@ -20,6 +20,7 @@ export async function planRepo(input: {
     "You are an agnostic, milestone-driven project planner.",
     "Use only neutral terms (entities, records, admin area, REST endpoints).",
     `Do not suggest changes in protected paths: ${input.protected.join(", ")}.`,
+    "If no vision is provided, continue without inventing one.",
     `Output sections in markdown with exact headings: \n` +
       "REPO_SUMMARY\n" +
       "STRUCTURE_FINDINGS\n" +

--- a/automation/review-repo.ts
+++ b/automation/review-repo.ts
@@ -119,10 +119,16 @@ async function main() {
   const roadmapDir = path.join(TARGET_PATH, "roadmap");
   const roadmapFresh = await readOr(path.join(roadmapDir, "new.md"));
   const roadmapTasks = await readOr(path.join(roadmapDir, "tasks.md"));
+  const visionLocal = await readOr(path.join(TARGET_PATH, "vision.md"));
+  const visionRoadmap = await readOr(path.join(roadmapDir, "vision.md"));
+  const vision = visionLocal || visionRoadmap;
+  if (visionLocal) console.log("found vision.md");
+  else if (visionRoadmap) console.log("found roadmap/vision.md");
+  else console.log("no vision file");
 
   const plan = await planRepo({
     manifest,
-    roadmap: { tasks: roadmapTasks, fresh: roadmapFresh },
+    roadmap: { tasks: roadmapTasks, fresh: roadmapFresh, vision },
     maxTasks: MAX_TASKS,
     protected: PROTECTED_PATHS,
   });

--- a/automation/review-repo.ts
+++ b/automation/review-repo.ts
@@ -1,0 +1,105 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { execSync } from "child_process";
+import { planRepo } from "./prompt.js";
+
+const TARGET_PATH = process.env.TARGET_PATH || "target";
+const MAX_FILES = parseInt(process.env.MAX_FILES || "800", 10);
+const MAX_BYTES_PER_FILE = parseInt(process.env.MAX_BYTES_PER_FILE || "50000", 10);
+const MAX_TASKS = parseInt(process.env.MAX_TASKS_PER_RUN || "5", 10);
+const PROTECTED_PATHS: string[] = JSON.parse(process.env.PROTECTED_PATHS || "[]");
+
+const IGNORE_DIRS = new Set(["node_modules", ".git", "dist", "build", "out"]);
+const TEXT_EXT = /\.(md|txt|js|ts|json|yaml|yml|html|css|py|java|go|rb|sh|c|cpp|cs)$/i;
+
+async function scanRepo(root: string) {
+  const topLevel = await fs.readdir(root);
+  const files: { path: string; sample: string }[] = [];
+  let fileCount = 0;
+  let dirCount = 0;
+  const dupMap = new Map<string, number>();
+
+  async function walk(cur: string) {
+    const entries = await fs.readdir(cur, { withFileTypes: true });
+    for (const e of entries) {
+      const full = path.join(cur, e.name);
+      const rel = path.relative(root, full).replace(/\\/g, "/");
+      if (IGNORE_DIRS.has(e.name)) continue;
+      if (e.isDirectory()) {
+        dirCount++;
+        dupMap.set(e.name, (dupMap.get(e.name) || 0) + 1);
+        await walk(full);
+      } else if (e.isFile()) {
+        fileCount++;
+        if (files.length < Math.min(MAX_FILES, 600) && TEXT_EXT.test(e.name)) {
+          try {
+            const buf = await fs.readFile(full);
+            const sample = buf.toString("utf8").slice(0, MAX_BYTES_PER_FILE);
+            files.push({ path: rel, sample });
+          } catch {}
+        }
+      }
+    }
+  }
+
+  await walk(root);
+  const duplicates = Array.from(dupMap.entries()).filter(([, c]) => c > 1).map(([n]) => n);
+  return { topLevel, fileCount, dirCount, duplicates, files };
+}
+
+async function writeFileSafe(p: string, content: string) {
+  const rel = path.relative(TARGET_PATH, p).replace(/\\/g, "/");
+  if (PROTECTED_PATHS.includes(rel)) {
+    throw new Error(`Refusing to write protected path: ${rel}`);
+  }
+  await fs.mkdir(path.dirname(p), { recursive: true });
+  await fs.writeFile(p, content);
+  console.log(`Wrote ${p}`);
+}
+
+async function main() {
+  const manifest = await scanRepo(TARGET_PATH);
+  console.log(`Scanned ${manifest.fileCount} files in ${manifest.dirCount} dirs`);
+  if (manifest.duplicates.length) {
+    console.log(`Duplicate dirs: ${manifest.duplicates.join(", ")}`);
+  }
+
+  const auditPath = path.join(TARGET_PATH, "audits", "repo-structure.md");
+  const auditContent = [
+    `# Repo Structure`,
+    `Scanned ${manifest.fileCount} files across ${manifest.dirCount} directories.`,
+    "", "## Top-level", ...manifest.topLevel.map(d => `- ${d}`),
+    "", "## Duplicate dir candidates", ...manifest.duplicates.map(d => `- ${d}`)
+  ].join("\n");
+  await writeFileSafe(auditPath, auditContent);
+
+  const roadmapNew = await readOptional(path.join(TARGET_PATH, "roadmap", "new.md"));
+  const roadmapTasks = await readOptional(path.join(TARGET_PATH, "roadmap", "tasks.md"));
+
+  const plan = await planRepo({
+    manifest,
+    roadmap: { tasks: roadmapTasks, fresh: roadmapNew },
+    maxTasks: MAX_TASKS,
+    protected: PROTECTED_PATHS,
+  });
+
+  await writeFileSafe(path.join(TARGET_PATH, "roadmap", "new.md"), plan);
+  await writeFileSafe(path.join(TARGET_PATH, "roadmap", "tasks.md"), plan);
+
+  try {
+    execSync('git config user.name "ai-dev-agent"', { cwd: TARGET_PATH });
+    execSync('git config user.email "bot@local"', { cwd: TARGET_PATH });
+    execSync('git add audits/*.md roadmap/*.md', { cwd: TARGET_PATH });
+    execSync('git commit -m "chore(agent): review + tasks"', { cwd: TARGET_PATH });
+    execSync('git push', { cwd: TARGET_PATH });
+    console.log("Committed roadmap and audits.");
+  } catch (err) {
+    console.log("No changes to commit");
+  }
+}
+
+async function readOptional(p: string): Promise<string> {
+  try { return await fs.readFile(p, "utf8"); } catch { return ""; }
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/automation/review-repo.ts
+++ b/automation/review-repo.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "fs";
 import path from "node:path";
 import crypto from "node:crypto";
-import { planRepo } from "./prompt";
+import { planRepo } from "./prompt.js";
 
 const TARGET_PATH = process.env.TARGET_PATH || "target";
 const MAX_FILES = parseInt(process.env.MAX_FILES || "800", 10);

--- a/automation/review-repo.ts
+++ b/automation/review-repo.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "fs";
 import path from "node:path";
 import crypto from "node:crypto";
-import { planRepo } from "./prompt.js";
+import { planRepo } from "./prompt";
 
 const TARGET_PATH = process.env.TARGET_PATH || "target";
 const MAX_FILES = parseInt(process.env.MAX_FILES || "800", 10);
@@ -127,7 +127,13 @@ async function main() {
     protected: PROTECTED_PATHS,
   });
 
+  const required = ["REPO_SUMMARY", "STRUCTURE_FINDINGS", "TOP_MILESTONE", "TASKS"];
+  const ok = required.every(h => plan.includes(h));
+  if (!ok) throw new Error("Planner output missing required sections");
+
   await writeFileSafe(path.join(roadmapDir, "new.md"), plan);
+  const taskCount = (plan.match(/^\s*-/mg) || []).length;
+  console.log(`roadmap/new.md tasks: ${taskCount}`);
 }
 
 async function readOr(p: string): Promise<string> {

--- a/dist/automation/prompt.js
+++ b/dist/automation/prompt.js
@@ -1,0 +1,37 @@
+import OpenAI from "openai";
+function requireEnv(names) {
+    for (const n of names) {
+        if (!process.env[n]) {
+            throw new Error(`Missing env: ${n}`);
+        }
+    }
+}
+export async function planRepo(input) {
+    requireEnv(["OPENAI_API_KEY", "OPENAI_MODEL"]);
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const system = [
+        "You are an agnostic, milestone-driven project planner.",
+        "Use only neutral terms (entities, records, admin area, REST endpoints).",
+        `Do not suggest changes in protected paths: ${input.protected.join(", ")}.`,
+        "If no vision is provided, continue without inventing one.",
+        `Output sections in markdown with exact headings: \n` +
+            "REPO_SUMMARY\n" +
+            "STRUCTURE_FINDINGS\n" +
+            "TOP_MILESTONE\n" +
+            "TASKS\n" +
+            "DONE_UPDATES",
+        "STRUCTURE_FINDINGS must contain 3-7 bullets.",
+        "TOP_MILESTONE is one of: Foundation, CRUD Admin, Public API, Dashboard, Import/Export, Auth, Polish.",
+        `TASKS: cap at ${input.maxTasks}. Each task must have Title, Rationale, Acceptance, Files, Tests.`,
+        "Reject micro-tasks unless they unblock the milestone."
+    ].join("\n");
+    const user = JSON.stringify({ manifest: input.manifest, roadmap: input.roadmap });
+    const r = await openai.chat.completions.create({
+        model: process.env.OPENAI_MODEL,
+        messages: [
+            { role: "system", content: system },
+            { role: "user", content: user }
+        ]
+    });
+    return r.choices[0]?.message?.content || "";
+}

--- a/dist/automation/review-repo.js
+++ b/dist/automation/review-repo.js
@@ -1,0 +1,144 @@
+import { promises as fs } from "fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { planRepo } from "./prompt.js";
+const TARGET_PATH = process.env.TARGET_PATH || "target";
+const MAX_FILES = parseInt(process.env.MAX_FILES || "800", 10);
+const MAX_BYTES_PER_FILE = parseInt(process.env.MAX_BYTES_PER_FILE || "50000", 10);
+const MAX_TASKS = parseInt(process.env.MAX_TASKS_PER_RUN || "5", 10);
+const PROTECTED_PATHS = JSON.parse(process.env.PROTECTED_PATHS || "[]");
+const IGNORE_DIRS = new Set([
+    "node_modules",
+    ".git",
+    ".next",
+    ".vercel",
+    ".turbo",
+    ".cache",
+    "dist",
+    "build",
+    "out",
+    "coverage",
+    ".pnpm-store"
+]);
+const TEXT_EXT = /\.(md|txt|js|jsx|ts|tsx|json|yaml|yml|html|css|mjs|cjs|py|java|go|rb|sh|c|cpp|cs)$/i;
+function dirSignature(entries) {
+    const sig = entries.filter(Boolean).sort().join("|");
+    return crypto.createHash("md5").update(sig).digest("hex");
+}
+async function scanRepo(root) {
+    const entriesTop = await fs.readdir(root, { withFileTypes: true });
+    const topLevel = entriesTop.filter(e => e.isDirectory()).map(e => e.name);
+    const files = [];
+    let fileCount = 0;
+    let dirCount = 0;
+    const byBasename = new Map();
+    async function walk(cur) {
+        const entries = await fs.readdir(cur, { withFileTypes: true });
+        for (const e of entries) {
+            const full = path.join(cur, e.name);
+            const rel = path.relative(root, full).replace(/\\/g, "/");
+            if (IGNORE_DIRS.has(e.name))
+                continue;
+            if (e.isDirectory()) {
+                dirCount++;
+                let childNames = [];
+                try {
+                    childNames = await fs.readdir(full);
+                }
+                catch { }
+                const sig = dirSignature(childNames);
+                const arr = byBasename.get(e.name) || [];
+                arr.push({ path: rel, sig });
+                byBasename.set(e.name, arr);
+                await walk(full);
+            }
+            else if (e.isFile()) {
+                fileCount++;
+                if (files.length < Math.min(MAX_FILES, 600) && TEXT_EXT.test(e.name)) {
+                    try {
+                        const buf = await fs.readFile(full, "utf8");
+                        files.push({ path: rel, sample: buf.slice(0, MAX_BYTES_PER_FILE) });
+                    }
+                    catch { }
+                }
+            }
+        }
+    }
+    await walk(root);
+    const duplicates = Array.from(byBasename.entries())
+        .flatMap(([base, arr]) => {
+        const bySig = new Map();
+        for (const { path: p, sig } of arr) {
+            bySig.set(sig, [...(bySig.get(sig) || []), p]);
+        }
+        return Array.from(bySig.values())
+            .filter(v => v.length > 1)
+            .map(members => ({ base, members }));
+    });
+    return { topLevel, fileCount, dirCount, duplicates, files };
+}
+async function writeFileSafe(p, content) {
+    const rel = path.relative(TARGET_PATH, p).replace(/\\/g, "/");
+    if (PROTECTED_PATHS.includes(rel)) {
+        throw new Error(`Refusing to write protected path: ${rel}`);
+    }
+    await fs.mkdir(path.dirname(p), { recursive: true });
+    await fs.writeFile(p, content);
+    console.log(`Wrote ${p}`);
+}
+async function main() {
+    const manifest = await scanRepo(TARGET_PATH);
+    console.log(`Scanned ${manifest.fileCount} files in ${manifest.dirCount} dirs`);
+    if (manifest.duplicates.length) {
+        console.log(`Duplicate dirs: ${manifest.duplicates.map(d => d.base).join(", ")}`);
+    }
+    const auditPath = path.join(TARGET_PATH, "audits", "repo-structure.md");
+    const dupLines = manifest.duplicates.length
+        ? manifest.duplicates.flatMap(d => [`- ${d.base}`, ...d.members.map(m => `  - ${m}`)])
+        : ["- none"];
+    const auditContent = [
+        `# Repo Structure`,
+        `Scanned ${manifest.fileCount} files across ${manifest.dirCount} directories.`,
+        "",
+        "## Top-level",
+        ...manifest.topLevel.map(d => `- ${d}`),
+        "",
+        "## Duplicate dir candidates",
+        ...dupLines
+    ].join("\n");
+    await writeFileSafe(auditPath, auditContent);
+    const roadmapDir = path.join(TARGET_PATH, "roadmap");
+    const roadmapFresh = await readOr(path.join(roadmapDir, "new.md"));
+    const roadmapTasks = await readOr(path.join(roadmapDir, "tasks.md"));
+    const visionLocal = await readOr(path.join(TARGET_PATH, "vision.md"));
+    const visionRoadmap = await readOr(path.join(roadmapDir, "vision.md"));
+    const vision = visionLocal || visionRoadmap;
+    if (visionLocal)
+        console.log("found vision.md");
+    else if (visionRoadmap)
+        console.log("found roadmap/vision.md");
+    else
+        console.log("no vision file");
+    const plan = await planRepo({
+        manifest,
+        roadmap: { tasks: roadmapTasks, fresh: roadmapFresh, vision },
+        maxTasks: MAX_TASKS,
+        protected: PROTECTED_PATHS,
+    });
+    const required = ["REPO_SUMMARY", "STRUCTURE_FINDINGS", "TOP_MILESTONE", "TASKS"];
+    const ok = required.every(h => plan.includes(h));
+    if (!ok)
+        throw new Error("Planner output missing required sections");
+    await writeFileSafe(path.join(roadmapDir, "new.md"), plan);
+    const taskCount = (plan.match(/^\s*-/mg) || []).length;
+    console.log(`roadmap/new.md tasks: ${taskCount}`);
+}
+async function readOr(p) {
+    try {
+        return await fs.readFile(p, "utf8");
+    }
+    catch {
+        return "";
+    }
+}
+main().catch(err => { console.error(err); process.exit(1); });

--- a/dist/automation/review-repo.js
+++ b/dist/automation/review-repo.js
@@ -86,6 +86,15 @@ async function writeFileSafe(p, content) {
     await fs.writeFile(p, content);
     console.log(`Wrote ${p}`);
 }
+async function readFirstExisting(base, rels) {
+    for (const r of rels) {
+        try {
+            return { path: r, content: await fs.readFile(path.join(base, r), "utf8") };
+        }
+        catch { }
+    }
+    return null;
+}
 async function main() {
     const manifest = await scanRepo(TARGET_PATH);
     console.log(`Scanned ${manifest.fileCount} files in ${manifest.dirCount} dirs`);
@@ -110,18 +119,11 @@ async function main() {
     const roadmapDir = path.join(TARGET_PATH, "roadmap");
     const roadmapFresh = await readOr(path.join(roadmapDir, "new.md"));
     const roadmapTasks = await readOr(path.join(roadmapDir, "tasks.md"));
-    const visionLocal = await readOr(path.join(TARGET_PATH, "vision.md"));
-    const visionRoadmap = await readOr(path.join(roadmapDir, "vision.md"));
-    const vision = visionLocal || visionRoadmap;
-    if (visionLocal)
-        console.log("found vision.md");
-    else if (visionRoadmap)
-        console.log("found roadmap/vision.md");
-    else
-        console.log("no vision file");
+    const visionFile = await readFirstExisting(TARGET_PATH, ["vision.md", "roadmap/vision.md"]);
+    console.log(`[review] vision doc: ${visionFile ? visionFile.path : "none"}`);
     const plan = await planRepo({
         manifest,
-        roadmap: { tasks: roadmapTasks, fresh: roadmapFresh, vision },
+        roadmap: { tasks: roadmapTasks, fresh: roadmapFresh, vision: visionFile?.content || "" },
         maxTasks: MAX_TASKS,
         protected: PROTECTED_PATHS,
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,52 +14,10 @@
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
-        "ts-node": "^10.9.1",
         "typescript": "^5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@octokit/app": {
@@ -438,34 +396,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz",
       "integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw=="
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.152",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.152.tgz",
@@ -524,32 +454,6 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -572,13 +476,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -641,13 +538,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -660,16 +550,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -974,13 +854,6 @@
         "node": "18 >=18.20 || 20 || >=22"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1144,50 +1017,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -1220,13 +1049,6 @@
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
       "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
     },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -1253,16 +1075,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,52 @@
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
+        "ts-node": "^10.9.1",
         "typescript": "^5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@octokit/app": {
@@ -396,6 +438,34 @@
       "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz",
       "integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw=="
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.152",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.152.tgz",
@@ -454,6 +524,32 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -476,6 +572,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -538,6 +641,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -550,6 +660,16 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -854,6 +974,13 @@
         "node": "18 >=18.20 || 20 || >=22"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1017,6 +1144,50 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -1049,6 +1220,13 @@
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
       "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -1075,6 +1253,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
   "js-yaml": "^4.1.0",
   "openai": "^4.58.0"
 },
-"devDependencies": {
-  "@types/js-yaml": "^4.0.9",
-  "typescript": "^5.5.4"
-}
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "typescript": "^5.5.4",
+    "ts-node": "^10.9.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,13 +16,12 @@
     "check": "node -e \"console.log('ok')\""
   },
   "dependencies": {
-  "octokit": "^3.x",
-  "js-yaml": "^4.1.0",
-  "openai": "^4.58.0"
-},
+    "js-yaml": "^4.1.0",
+    "octokit": "^3.x",
+    "openai": "^4.58.0"
+  },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
-    "typescript": "^5.5.4",
-    "ts-node": "^10.9.1"
+    "typescript": "^5.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && tsc automation/prompt.ts automation/review-repo.ts --outDir dist/automation --rootDir automation --module NodeNext --moduleResolution NodeNext --target ES2022 --esModuleInterop --skipLibCheck",
+    "build": "tsc -p tsconfig.json && tsc automation/prompt.ts automation/review-repo.ts --outDir dist/automation --rootDir automation --module ES2022 --moduleResolution bundler --target ES2022 --esModuleInterop --skipLibCheck && node -e \"const fs=require('fs');const p='dist/automation/review-repo.js';fs.writeFileSync(p,fs.readFileSync(p,'utf8').replace('./prompt','./prompt.js'));\"",
     "start": "node dist/cli.js",
     "cmd:ingest-logs": "node dist/cli.js ingest-logs",
     "cmd:review-repo": "node dist/cli.js review-repo",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "build": "tsc -p tsconfig.json && tsc automation/prompt.ts automation/review-repo.ts --outDir dist/automation --rootDir automation --module ES2022 --moduleResolution bundler --target ES2022 --esModuleInterop --skipLibCheck && node -e \"const fs=require('fs');const p='dist/automation/review-repo.js';fs.writeFileSync(p,fs.readFileSync(p,'utf8').replace('./prompt','./prompt.js'));\"",
     "start": "node dist/cli.js",
     "cmd:ingest-logs": "node dist/cli.js ingest-logs",
-    "cmd:review-repo": "node dist/cli.js review-repo",
     "cmd:synthesize-tasks": "node dist/cli.js synthesize-tasks",
     "cmd:implement": "node dist/cli.js implement",
     "check": "node -e \"console.log('ok')\""

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && tsc automation/prompt.ts automation/review-repo.ts --outDir dist/automation --rootDir automation --module NodeNext --moduleResolution NodeNext --target ES2022 --esModuleInterop --skipLibCheck",
     "start": "node dist/cli.js",
     "cmd:ingest-logs": "node dist/cli.js ingest-logs",
     "cmd:review-repo": "node dist/cli.js review-repo",


### PR DESCRIPTION
## Summary
- Scan target repositories recursively, build a compact manifest, and log repo structure while guarding protected paths.
- Generate milestone-gated, domain-neutral plans via a new prompt ensuring capped task counts and required sections.
- Update workflow to checkout target repo into `target/`, set scanning limits, and run the new TypeScript review script.

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689f2300b8b0832a86decdc478aa976b