### PR TITLE
chore: tighten repo review limits

### DIFF
--- a/.github/workflows/agent-review-repo.yml
+++ b/.github/workflows/agent-review-repo.yml
@@ -37,12 +37,15 @@ jobs:
       - run: node dist/automation/review-repo.js
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_MODEL: gpt-5
           TARGET_PATH: target
-          MAX_FILES: 800
-          MAX_BYTES_PER_FILE: 50000
+          MAX_FILES: "180"
+          MAX_SAMPLED_FILES: "80"
+          MAX_BYTES_PER_FILE: "1500"
+          MAX_INPUT_CHARS: "80000"
+          MAX_OUTPUT_TOKENS: "1200"
           MAX_TASKS_PER_RUN: 5
-          PROTECTED_PATHS: '["roadmap/vision.md","vision.md"]'
+          PROTECTED_PATHS: '["vision.md","roadmap/vision.md"]'
+          PLANNER_MODEL: "gpt-4.1-mini"
       - name: Commit roadmap & audits to target
         working-directory: target
         run: |

--- a/automation/prompt.ts
+++ b/automation/prompt.ts
@@ -10,12 +10,15 @@ function requireEnv(names: string[]): void {
 
 export async function planRepo(input: {
   manifest: any;
-  roadmap: { tasks: string; fresh: string; vision: string };
+  roadmap: { tasks: string; fresh: string };
+  vision: { path: string; content: string };
   maxTasks: number;
   protected: string[];
 }): Promise<string> {
-  requireEnv(["OPENAI_API_KEY", "OPENAI_MODEL"]);
-  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+  requireEnv(["OPENAI_API_KEY"]);
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+  const model = process.env.PLANNER_MODEL || "gpt-5";
+  const maxOutput = Number(process.env.MAX_OUTPUT_TOKENS || 1200);
   const system = [
     "You are an agnostic, milestone-driven project planner.",
     "Use only neutral terms (entities, records, admin area, REST endpoints).",
@@ -33,13 +36,15 @@ export async function planRepo(input: {
     "Reject micro-tasks unless they unblock the milestone."
   ].join("\n");
 
-  const user = JSON.stringify({ manifest: input.manifest, roadmap: input.roadmap });
-  const r = await openai.chat.completions.create({
-    model: process.env.OPENAI_MODEL!,
+  const user = JSON.stringify({ manifest: input.manifest, roadmap: input.roadmap, vision: input.vision });
+  const r = await client.chat.completions.create({
+    model,
+    temperature: 0.2,
+    max_output_tokens: maxOutput,
     messages: [
       { role: "system", content: system },
       { role: "user", content: user }
     ]
-  });
+  } as any);
   return r.choices[0]?.message?.content || "";
 }

--- a/dist/automation/review-repo.js
+++ b/dist/automation/review-repo.js
@@ -3,8 +3,10 @@ import path from "node:path";
 import crypto from "node:crypto";
 import { planRepo } from "./prompt.js";
 const TARGET_PATH = process.env.TARGET_PATH || "target";
-const MAX_FILES = parseInt(process.env.MAX_FILES || "800", 10);
-const MAX_BYTES_PER_FILE = parseInt(process.env.MAX_BYTES_PER_FILE || "50000", 10);
+const MAX_FILES = Number(process.env.MAX_FILES || 180);
+const MAX_SAMPLED_FILES = Number(process.env.MAX_SAMPLED_FILES || 80);
+const MAX_BYTES = Number(process.env.MAX_BYTES_PER_FILE || 1500);
+const MAX_INPUT_CHARS = Number(process.env.MAX_INPUT_CHARS || 80000);
 const MAX_TASKS = parseInt(process.env.MAX_TASKS_PER_RUN || "5", 10);
 const PROTECTED_PATHS = JSON.parse(process.env.PROTECTED_PATHS || "[]");
 const IGNORE_DIRS = new Set([
@@ -26,11 +28,8 @@ function dirSignature(entries) {
     return crypto.createHash("md5").update(sig).digest("hex");
 }
 async function scanRepo(root) {
-    const entriesTop = await fs.readdir(root, { withFileTypes: true });
-    const topLevel = entriesTop.filter(e => e.isDirectory()).map(e => e.name);
     const files = [];
-    let fileCount = 0;
-    let dirCount = 0;
+    const dirs = [];
     const byBasename = new Map();
     async function walk(cur) {
         const entries = await fs.readdir(cur, { withFileTypes: true });
@@ -40,7 +39,7 @@ async function scanRepo(root) {
             if (IGNORE_DIRS.has(e.name))
                 continue;
             if (e.isDirectory()) {
-                dirCount++;
+                dirs.push({ path: rel });
                 let childNames = [];
                 try {
                     childNames = await fs.readdir(full);
@@ -53,14 +52,19 @@ async function scanRepo(root) {
                 await walk(full);
             }
             else if (e.isFile()) {
-                fileCount++;
-                if (files.length < Math.min(MAX_FILES, 600) && TEXT_EXT.test(e.name)) {
-                    try {
-                        const buf = await fs.readFile(full, "utf8");
-                        files.push({ path: rel, sample: buf.slice(0, MAX_BYTES_PER_FILE) });
+                try {
+                    const stat = await fs.stat(full);
+                    let sample;
+                    if (TEXT_EXT.test(e.name)) {
+                        try {
+                            const buf = await fs.readFile(full, "utf8");
+                            sample = buf.slice(0, MAX_BYTES);
+                        }
+                        catch { }
                     }
-                    catch { }
+                    files.push({ path: rel, size: stat.size, sample });
                 }
+                catch { }
             }
         }
     }
@@ -75,7 +79,7 @@ async function scanRepo(root) {
             .filter(v => v.length > 1)
             .map(members => ({ base, members }));
     });
-    return { topLevel, fileCount, dirCount, duplicates, files };
+    return { files, dirs, duplicates };
 }
 async function writeFileSafe(p, content) {
     const rel = path.relative(TARGET_PATH, p).replace(/\\/g, "/");
@@ -86,44 +90,98 @@ async function writeFileSafe(p, content) {
     await fs.writeFile(p, content);
     console.log(`Wrote ${p}`);
 }
-async function readFirstExisting(base, rels) {
-    for (const r of rels) {
-        try {
-            return { path: r, content: await fs.readFile(path.join(base, r), "utf8") };
-        }
-        catch { }
-    }
-    return null;
-}
 async function main() {
-    const manifest = await scanRepo(TARGET_PATH);
-    console.log(`Scanned ${manifest.fileCount} files in ${manifest.dirCount} dirs`);
-    if (manifest.duplicates.length) {
-        console.log(`Duplicate dirs: ${manifest.duplicates.map(d => d.base).join(", ")}`);
+    const { files, dirs, duplicates } = await scanRepo(TARGET_PATH);
+    console.log(`Scanned ${files.length} files in ${dirs.length} dirs`);
+    if (duplicates.length) {
+        console.log(`Duplicate dirs: ${duplicates.map(d => d.base).join(", ")}`);
     }
+    const topLevel = dirs.filter(d => !d.path.includes(path.sep)).map(d => d.path);
     const auditPath = path.join(TARGET_PATH, "audits", "repo-structure.md");
-    const dupLines = manifest.duplicates.length
-        ? manifest.duplicates.flatMap(d => [`- ${d.base}`, ...d.members.map(m => `  - ${m}`)])
+    const dupLines = duplicates.length
+        ? duplicates.flatMap(d => [`- ${d.base}`, ...d.members.map(m => `  - ${m}`)])
         : ["- none"];
     const auditContent = [
         `# Repo Structure`,
-        `Scanned ${manifest.fileCount} files across ${manifest.dirCount} directories.`,
+        `Scanned ${files.length} files across ${dirs.length} directories.`,
         "",
         "## Top-level",
-        ...manifest.topLevel.map(d => `- ${d}`),
+        ...topLevel.map(d => `- ${d}`),
         "",
         "## Duplicate dir candidates",
         ...dupLines
     ].join("\n");
     await writeFileSafe(auditPath, auditContent);
+    // PRIORITIZE routes/config/docs; sample only a subset
+    const PRIORITY = [
+        /^package\.json$/i,
+        /^tsconfig\.json$/i,
+        /^next\.config\.(js|ts|mjs|cjs)$/i,
+        /^readme\.md$/i,
+        /^roadmap\/[^/]+\.md$/i,
+        /^(app|pages)\//i,
+        /^src\/(app|pages|api|lib|components|routes)\//i
+    ];
+    const score = (p) => {
+        for (let i = 0; i < PRIORITY.length; i++)
+            if (PRIORITY[i].test(p))
+                return i;
+        return PRIORITY.length;
+    };
+    const sorted = files.slice().sort((a, b) => score(a.path) - score(b.path) || b.size - a.size);
+    const head = sorted.slice(0, MAX_FILES);
+    const sampled = new Set(head.slice(0, MAX_SAMPLED_FILES).map(f => f.path));
+    const manifestFiles = head.map(f => ({
+        path: f.path,
+        size: f.size,
+        sample: (sampled.has(f.path) && f.sample)
+            ? f.sample.slice(0, MAX_BYTES)
+            : undefined
+    }));
+    let manifest = {
+        stats: {
+            files: files.length,
+            dirs: dirs.length,
+            protectedPaths: PROTECTED_PATHS,
+        },
+        topLevel,
+        duplicates,
+        files: manifestFiles
+    };
+    // Trim roadmap/vision inputs and enforce a global budget
+    const trim = (s, n) => (s && s.length > n ? s.slice(0, n) : (s || ""));
+    const READ_LIMIT = 8000;
+    const readOr = async (p) => { try {
+        return trim(await fs.readFile(p, "utf8"), READ_LIMIT);
+    }
+    catch {
+        return "";
+    } };
     const roadmapDir = path.join(TARGET_PATH, "roadmap");
     const roadmapFresh = await readOr(path.join(roadmapDir, "new.md"));
     const roadmapTasks = await readOr(path.join(roadmapDir, "tasks.md"));
-    const visionFile = await readFirstExisting(TARGET_PATH, ["vision.md", "roadmap/vision.md"]);
-    console.log(`[review] vision doc: ${visionFile ? visionFile.path : "none"}`);
+    const vision = await (async () => {
+        for (const rel of ["vision.md", "roadmap/vision.md"]) {
+            try {
+                return { path: rel, content: trim(await fs.readFile(path.join(TARGET_PATH, rel), "utf8"), READ_LIMIT) };
+            }
+            catch { }
+        }
+        return { path: "", content: "" };
+    })();
+    const sizeOf = (obj) => JSON.stringify(obj).length
+        + roadmapFresh.length + roadmapTasks.length + vision.content.length;
+    while (sizeOf(manifest) > MAX_INPUT_CHARS) {
+        const idx = manifest.files.findLastIndex((f) => !!f.sample);
+        if (idx === -1)
+            break;
+        manifest.files[idx].sample = undefined;
+    }
+    console.log(`[review] vision doc: ${vision.path || "none"}`);
     const plan = await planRepo({
         manifest,
-        roadmap: { tasks: roadmapTasks, fresh: roadmapFresh, vision: visionFile?.content || "" },
+        roadmap: { tasks: roadmapTasks, fresh: roadmapFresh },
+        vision,
         maxTasks: MAX_TASKS,
         protected: PROTECTED_PATHS,
     });
@@ -134,13 +192,5 @@ async function main() {
     await writeFileSafe(path.join(roadmapDir, "new.md"), plan);
     const taskCount = (plan.match(/^\s*-/mg) || []).length;
     console.log(`roadmap/new.md tasks: ${taskCount}`);
-}
-async function readOr(p) {
-    try {
-        return await fs.readFile(p, "utf8");
-    }
-    catch {
-        return "";
-    }
 }
 main().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- cap review job input and output sizes to avoid token overuse
- prioritize and sample important files when building manifest
- allow selecting lighter planning model with token cap

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689f3e26252c832a990b3ce36950b95c