### PR TITLE
refactor: emit bare planner headings

### DIFF
--- a/automation/prompt.ts
+++ b/automation/prompt.ts
@@ -27,7 +27,7 @@ export async function planRepo(input: {
     "Use only neutral terms (entities, records, admin area, REST endpoints).",
     `Do not suggest changes in protected paths: ${input.protected.join(", ")}.`,
     "If no vision is provided, continue without inventing one.",
-    "Output sections in markdown with exact headings:",
+    "Output sections as PLAIN TEXT headings with NO leading '#', '##', or formatting. Each heading must be EXACTLY the section name on its own line:",
     "REPO_SUMMARY",
     "STRUCTURE_FINDINGS",
     "TOP_MILESTONE",

--- a/dist/automation/prompt.js
+++ b/dist/automation/prompt.js
@@ -10,28 +10,32 @@ export async function planRepo(input) {
     requireEnv(["OPENAI_API_KEY"]);
     const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
     const model = process.env.PLANNER_MODEL || "gpt-5";
-    const maxOutput = Number(process.env.MAX_OUTPUT_TOKENS || 1200);
+    const maxTokens = Number(process.env.MAX_TOKENS || process.env.MAX_OUTPUT_TOKENS || 1200);
     const system = [
         "You are an agnostic, milestone-driven project planner.",
         "Use only neutral terms (entities, records, admin area, REST endpoints).",
         `Do not suggest changes in protected paths: ${input.protected.join(", ")}.`,
         "If no vision is provided, continue without inventing one.",
-        `Output sections in markdown with exact headings: \n` +
-            "REPO_SUMMARY\n" +
-            "STRUCTURE_FINDINGS\n" +
-            "TOP_MILESTONE\n" +
-            "TASKS\n" +
-            "DONE_UPDATES",
+        "Output sections as PLAIN TEXT headings with NO leading '#', '##', or formatting. Each heading must be EXACTLY the section name on its own line:",
+        "REPO_SUMMARY",
+        "STRUCTURE_FINDINGS",
+        "TOP_MILESTONE",
+        "TASKS",
+        "DONE_UPDATES",
         "STRUCTURE_FINDINGS must contain 3-7 bullets.",
         "TOP_MILESTONE is one of: Foundation, CRUD Admin, Public API, Dashboard, Import/Export, Auth, Polish.",
         `TASKS: cap at ${input.maxTasks}. Each task must have Title, Rationale, Acceptance, Files, Tests.`,
         "Reject micro-tasks unless they unblock the milestone."
     ].join("\n");
-    const user = JSON.stringify({ manifest: input.manifest, roadmap: input.roadmap, vision: input.vision });
+    const user = JSON.stringify({
+        manifest: input.manifest,
+        roadmap: input.roadmap,
+        vision: input.vision
+    });
     const r = await client.chat.completions.create({
         model,
         temperature: 0.2,
-        max_output_tokens: maxOutput,
+        max_tokens: maxTokens, // ✅ correct param & variable
         messages: [
             { role: "system", content: system },
             { role: "user", content: user }

--- a/dist/automation/review-repo.js
+++ b/dist/automation/review-repo.js
@@ -185,12 +185,38 @@ async function main() {
         maxTasks: MAX_TASKS,
         protected: PROTECTED_PATHS,
     });
-    const required = ["REPO_SUMMARY", "STRUCTURE_FINDINGS", "TOP_MILESTONE", "TASKS"];
-    const ok = required.every(h => plan.includes(h));
-    if (!ok)
-        throw new Error("Planner output missing required sections");
-    await writeFileSafe(path.join(roadmapDir, "new.md"), plan);
-    const taskCount = (plan.match(/^\s*-/mg) || []).length;
+    function normalizeHeadings(s) {
+        const heads = [
+            "REPO_SUMMARY",
+            "STRUCTURE_FINDINGS",
+            "TOP_MILESTONE",
+            "TASKS",
+            "DONE_UPDATES"
+        ];
+        const rx = new RegExp(`^\\s*#{1,6}\\s*(${heads.join("|")})\\s*$`, "i");
+        return s
+            .split("\n")
+            .map(line => {
+            const m = line.match(rx);
+            return m ? m[1].toUpperCase() : line;
+        })
+            .join("\n");
+    }
+    let output = plan;
+    // ensure bare headings even if the model renders markdown
+    output = normalizeHeadings(output);
+    // (optional sanity check)
+    const required = [
+        "REPO_SUMMARY",
+        "STRUCTURE_FINDINGS",
+        "TOP_MILESTONE",
+        "TASKS"
+    ];
+    if (!required.every(h => new RegExp(`^${h}\\s*$`, "m").test(output))) {
+        throw new Error("Planner output missing bare section headings");
+    }
+    await writeFileSafe(path.join(roadmapDir, "new.md"), output);
+    const taskCount = (output.match(/^\s*-/gm) || []).length;
     console.log(`roadmap/new.md tasks: ${taskCount}`);
 }
 main().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- instruct planner to use plain text section headers
- normalize headings in roadmap output to avoid markdown prefixes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689f44d76054832a8d74ff7ba6e38e2a