### PR TITLE
feat(review): Refactor review-repo to produce actionable tasks

### DIFF
--- a/dist/lib/env.js
+++ b/dist/lib/env.js
@@ -8,7 +8,7 @@ export const ENV = {
     VERCEL_TEAM_ID: process.env.VERCEL_TEAM_ID || "",
     VERCEL_TOKEN: process.env.VERCEL_TOKEN || "",
     OPENAI_API_KEY: process.env.OPENAI_API_KEY || "",
-    OPENAI_MODEL: process.env.OPENAI_MODEL || "gpt-4o-mini",
+    OPENAI_MODEL: process.env.OPENAI_MODEL || "",
     WRITE_MODE: process.env.AI_BOT_WRITE_MODE || "commit",
     DRY_RUN: process.env.DRY_RUN === "1",
     BRANCH: process.env.GITHUB_REF_NAME || process.env.GITHUB_HEAD_REF || "",

--- a/dist/lib/prompts.js
+++ b/dist/lib/prompts.js
@@ -1,101 +1,90 @@
 // src/lib/prompts.ts
 import OpenAI from "openai";
 import { ENV, requireEnv } from "./env.js";
-
 /** Lazily get an OpenAI client only when needed */
 function getOpenAI() {
-  requireEnv(["OPENAI_API_KEY"]);
-  return new OpenAI({ apiKey: ENV.OPENAI_API_KEY });
+    requireEnv(["OPENAI_API_KEY"]);
+    return new OpenAI({ apiKey: ENV.OPENAI_API_KEY });
 }
-
-/** Types */
-export type LogEntryForBug = {
-  level: "error" | "warning";
-  message: string;
-  path?: string;
-  ts?: string;
-};
-
 /**
  * Turn runtime/build log entries into a short bug description list.
  * Return is free-form markdown/text that the caller writes into bugs.md.
  */
-export async function summarizeLogToBug(entries: LogEntryForBug[]): Promise<string> {
-  const openai = getOpenAI();
-  const messages = [
-    {
-      role: "system" as const,
-      content:
-        "You are an experienced software architect. Convert each unique error/warning into a succinct bug with a short title and 2–4 line description. No priorities, no duplicates. Output concise markdown."
-    },
-    { role: "user" as const, content: JSON.stringify(entries, null, 2) }
-  ];
-  const r = await openai.chat.completions.create({
-    model: ENV.OPENAI_MODEL,
-    messages
-  });
-  return r.choices[0]?.message?.content ?? "";
+export async function summarizeLogToBug(entries) {
+    const openai = getOpenAI();
+    const messages = [
+        {
+            role: "system",
+            content: "You are an experienced software architect. Convert each unique error/warning into a succinct bug with a short title and 2–4 line description. No priorities, no duplicates. Output concise markdown."
+        },
+        { role: "user", content: JSON.stringify(entries, null, 2) }
+    ];
+    const r = await openai.chat.completions.create({
+        model: ENV.OPENAI_MODEL,
+        messages
+    });
+    return r.choices[0]?.message?.content ?? "";
 }
-
 /**
- * Quick repo review → ideas/improvements in YAML (under queue:).
+ * Quick repo review → high-level summary in markdown.
+ */
+export async function reviewToSummary(input) {
+    const openai = getOpenAI();
+    const messages = [
+        {
+            role: "system",
+            content: "You are an experienced software architect. Review the provided repository context and write a high-level summary of the current status, recent activity, and potential areas for improvement. Output should be human-readable markdown, suitable for a technical project manager."
+        },
+        { role: "user", content: JSON.stringify(input, null, 2) }
+    ];
+    const r = await openai.chat.completions.create({
+        model: ENV.OPENAI_MODEL,
+        messages
+    });
+    return r.choices[0]?.message?.content ?? "";
+}
+/**
+ * Repo review summary → ideas/improvements in YAML (under queue:).
  * Caller will parse/merge the YAML; duplicates should be minimized.
  */
-export async function reviewToIdeas(input: {
-  commits: string[];
-  vision: string;
-  tasks: string;
-  bugs: string;
-  done: string;
-  fresh: string; // current new.md content
-}): Promise<string> {
-  const openai = getOpenAI();
-  const messages = [
-    {
-      role: "system" as const,
-      content:
-        "You are an experienced software architect. Propose, actionable items for code bot based on the context. Include tasks that make visible progress for the end user." +
-        "Return ONLY YAML in a code block with the shape:\n```yaml\nqueue:\n  - id: <leave blank or omit>\n    title: <short>\n    details: <1-3 lines>\n    created: <ISO>\n```" +
-        "\nAvoid duplicates vs the provided lists."
-    },
-    { role: "user" as const, content: JSON.stringify(input, null, 2) }
-  ];
-  const r = await openai.chat.completions.create({
-    model: ENV.OPENAI_MODEL,
-    messages
-  });
-  return r.choices[0]?.message?.content ?? "";
+export async function reviewToIdeas(input) {
+    const openai = getOpenAI();
+    const messages = [
+        {
+            role: "system",
+            content: "You are an experienced software architect. Based on the provided summary and other context, propose concise, actionable items for a code bot. Include tasks that make visible progress for the end user." +
+                "Return ONLY YAML in a code block with the shape:\n```yaml\nqueue:\n  - id: <leave blank or omit>\n    title: <short>\n    details: <1-3 lines>\n    created: <ISO>\n```" +
+                "\nAvoid duplicates vs the provided lists. Focus on the opportunities identified in the summary."
+        },
+        { role: "user", content: JSON.stringify(input, null, 2) }
+    ];
+    const r = await openai.chat.completions.create({
+        model: ENV.OPENAI_MODEL,
+        messages
+    });
+    return r.choices[0]?.message?.content ?? "";
 }
-
 /**
  * Promote items from roadmap/new.md (ideas queue) → tasks with unique priorities (1..N).
  * Return YAML (items: [...]) in a code block; caller merges & enforces limits.
  */
-export async function synthesizeTasksPrompt(input: {
-  tasks: string;
-  bugs: string;
-  ideas: string;
-  vision: string;
-  done: string;
-}): Promise<string> {
-  const openai = getOpenAI();
-  const messages = [
-    {
-      role: "system" as const,
-      content:
-        "Promote items from roadmap/new.md (ideas queue) into tasks.\n" +
-        "Return ONLY YAML in a code block with the shape:\n```yaml\nitems:\n  - id: <leave blank or omit>\n    type: bug|improvement|feature\n    title: <short>\n    desc: <2–4 lines>\n    source: logs|review|user|vision\n    created: <ISO>\n    priority: <int>\n```\n" +
-        "Rules: no duplicates vs existing tasks; unique priorities 1..N; prefer critical bugs and user-impactful work; cap at ~100."
-    },
-    { role: "user" as const, content: JSON.stringify(input, null, 2) }
-  ];
-  const r = await openai.chat.completions.create({
-    model: ENV.OPENAI_MODEL,
-    messages
-  });
-  return r.choices[0]?.message?.content ?? "";
+export async function synthesizeTasksPrompt(input) {
+    const openai = getOpenAI();
+    const messages = [
+        {
+            role: "system",
+            content: "Promote items from roadmap/new.md (ideas queue) into tasks.\n" +
+                "Return ONLY YAML in a code block with the shape:\n```yaml\nitems:\n  - id: <leave blank or omit>\n    type: bug|improvement|feature\n    title: <short>\n    desc: <2–4 lines>\n    source: logs|review|user|vision\n    created: <ISO>\n    priority: <int>\n```\n" +
+                "Rules: no duplicates vs existing tasks; unique priorities 1..N; prefer critical bugs and user-impactful work; cap at ~100."
+        },
+        { role: "user", content: JSON.stringify(input, null, 2) }
+    ];
+    const r = await openai.chat.completions.create({
+        model: ENV.OPENAI_MODEL,
+        messages
+    });
+    return r.choices[0]?.message?.content ?? "";
 }
-
 /**
  * Plan minimal code changes for the top task.
  * Returns a JSON string the caller will JSON.parse().
@@ -107,26 +96,20 @@ export async function synthesizeTasksPrompt(input: {
  *   commitBody: string
  * }
  */
-export async function implementPlan(input: {
-  vision: string;
-  done: string;
-  topTask: any;
-  repoTree: string[]; // optional list of known files; may be empty
-}): Promise<string> {
-  const openai = getOpenAI();
-  const messages = [
-    {
-      role: "system" as const,
-      content:
-        "You are a senior developer. Develope task and deliver in a safe diff. " +
-        "Output ONLY JSON with keys: operations (array of {path, action:create|update, content?}), testHint, commitTitle, commitBody. " +
-        "Keep diffs tangible; only files relevant to the task; include at least one test file if a test harness exists; avoid broad refactors."
-    },
-    { role: "user" as const, content: JSON.stringify(input, null, 2) }
-  ];
-  const r = await openai.chat.completions.create({
-    model: ENV.OPENAI_MODEL,
-    messages
-  });
-  return r.choices[0]?.message?.content ?? "{}";
+export async function implementPlan(input) {
+    const openai = getOpenAI();
+    const messages = [
+        {
+            role: "system",
+            content: "You are a senior developer. Develope task and deliver in a safe diff. " +
+                "Output ONLY JSON with keys: operations (array of {path, action:create|update, content?}), testHint, commitTitle, commitBody. " +
+                "Keep diffs tangible; only files relevant to the task; include at least one test file if a test harness exists; avoid broad refactors."
+        },
+        { role: "user", content: JSON.stringify(input, null, 2) }
+    ];
+    const r = await openai.chat.completions.create({
+        model: ENV.OPENAI_MODEL,
+        messages
+    });
+    return r.choices[0]?.message?.content ?? "{}";
 }

--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -1,9 +1,10 @@
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { readFile, parseRepo, gh, upsertFile } from "../lib/github.js";
 import { readYamlBlock, writeYamlBlock } from "../lib/md.js";
-import { reviewToIdeas } from "../lib/prompts.js";
+import { reviewToIdeas, reviewToSummary } from "../lib/prompts.js";
 import { loadState, saveState } from "../lib/state.js";
 import { requireEnv, ENV } from "../lib/env.js";
+import yaml from "js-yaml";
 
 export async function reviewRepo() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
@@ -28,16 +29,33 @@ export async function reviewRepo() {
       (c: { sha: string; commit: { message: string } }) =>
         `${c.sha.slice(0,7)} ${c.commit.message.split("\n")[0]}`
     );
-    const input = { commits: recent, vision, tasks, bugs, done, fresh };
 
-    const ideas = await reviewToIdeas(input);
+    // 1. Generate high-level summary
+    const summaryInput = { commits: recent, vision, tasks, bugs, done, fresh };
+    const summary = await reviewToSummary(summaryInput);
+    await upsertFile("reports/repo_summary.md", () => summary, "bot: update repo summary");
+
+    // 2. Generate actionable ideas from summary
+    const ideasInput = { summary, vision, tasks, bugs, done, fresh };
+    const ideasYaml = await reviewToIdeas(ideasInput);
+
+    // 3. Append new ideas to roadmap/new.md
     const newPath = "roadmap/new.md";
-    const current = (await readFile(newPath)) || "";
-    const yaml = readYamlBlock<{ queue: any[] }>(current, { queue: [] });
-    yaml.queue.push({ id: `IDEA-${Date.now()}`, title: "Architect review batch", details: ideas, created: new Date().toISOString() });
-    const next = writeYamlBlock(current, yaml);
+    const currentNewMd = (await readFile(newPath)) || "";
+    const currentIdeas = readYamlBlock<{ queue: any[] }>(currentNewMd, { queue: [] });
 
-    await upsertFile(newPath, () => next, "bot: review repo → new.md");
+    const newIdeas = (yaml.load(ideasYaml) as { queue: any[] })?.queue || [];
+
+    for (const idea of newIdeas) {
+      currentIdeas.queue.push({
+        ...idea,
+        id: idea.id || `IDEA-${Date.now()}`,
+        created: idea.created || new Date().toISOString()
+      });
+    }
+
+    const nextNewMd = writeYamlBlock(currentNewMd, currentIdeas);
+    await upsertFile(newPath, () => nextNewMd, "bot: review repo → new.md");
 
     const headSha = commitsData[0]?.sha;
     await saveState({ ...state, lastReviewedSha: headSha });


### PR DESCRIPTION
The review-repo feature was generating a single, large summary file in roadmap/new.md. This was not easily parsable by the synthesize-tasks feature, which would then delete the summary.

This commit refactors the process into two steps:
1. A high-level summary of the repository's status is generated and saved to reports/repo_summary.md.
2. Concise, actionable ideas are generated in YAML format based on this summary. These ideas are then parsed and appended to the queue in roadmap/new.md, preserving any existing items.

This change aligns the feature with the process described in the README.md and ensures that the synthesize-tasks feature receives a stream of well-structured, machine-readable tasks.