### PR TITLE
feat: support commit bodies for automated updates

### DIFF
--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -104,11 +104,38 @@ export async function implementTopTask() {
     const nextDone = done + doneLine;
 
     if (files.length) {
-      const title = plan.commitTitle || ((top.type === "bug" ? "fix" : "feat") + `: ${top.title || top.id}`);
+      // Build commit body describing root cause, scope, and validation
+      const cb: any = typeof plan.commitBody === "object" ? plan.commitBody : {};
+      const rootCause = cb.rootCause || top.desc || "n/a";
+      const scope = cb.scope || files.map(f => f.path).join(", ");
+      const validation = cb.validation || plan.testHint || "n/a";
+      const logLink = cb.logUrl || cb.logs || cb.log || undefined;
+      const commitBody = [
+        `Root Cause: ${rootCause}`,
+        `Scope: ${scope}`,
+        `Validation: ${validation}`,
+        `Links:\n- [Roadmap](roadmap/tasks.md)` + (logLink ? `\n- Logs: ${logLink}` : "")
+      ].join("\n\n");
+
+      let title = plan.commitTitle || ((top.type === "bug" ? "fix" : "feat") + `: ${top.title || top.id}`);
+      if (!/^[a-z]+:\s/.test(title)) {
+        const prefix = top.type === "bug" ? "fix" : "feat";
+        title = `${prefix}: ${title}`;
+      }
       try {
-        await commitMany(files, title, { branch: targetBranch });
-        await upsertFile("roadmap/tasks.md", () => nextTasks, "bot: remove completed task", { branch: targetBranch });
-        await upsertFile("roadmap/done.md", () => nextDone, "bot: append done item", { branch: targetBranch });
+        await commitMany(files, { title, body: commitBody }, { branch: targetBranch });
+        await upsertFile(
+          "roadmap/tasks.md",
+          () => nextTasks,
+          { title: "chore: remove completed task", body: commitBody },
+          { branch: targetBranch }
+        );
+        await upsertFile(
+          "roadmap/done.md",
+          () => nextDone,
+          { title: "chore: append done item", body: commitBody },
+          { branch: targetBranch }
+        );
         console.log("Implement complete.");
       } catch (err) {
         console.error("Bulk commit failed; no changes were applied.", err);


### PR DESCRIPTION
## Summary
- support commit body in commitMany/upsertFile so automation can send multi-line messages
- implement detailed commit bodies in implementTopTask with root cause, scope, validation, and roadmap links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b5d7ea9420832a8ad7a85da6b29062