### PR TITLE
feat: add orchestrator to manage agent tasks

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -25,8 +25,9 @@ jobs:
           fi
       - run: npm ci --no-audit --no-fund
       - run: npm run build
-      - run: node dist/cli.js implement
+      - run: node dist/orchestrator.js
         env:
+          RUN_TASK: implement
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
           TARGET_REPO: ${{ secrets.TARGET_REPO }}

--- a/.github/workflows/agent-ingest-logs.yml
+++ b/.github/workflows/agent-ingest-logs.yml
@@ -25,8 +25,9 @@ jobs:
           fi
       - run: npm ci --no-audit --no-fund
       - run: npm run build
-      - run: node dist/cli.js ingest-logs
+      - run: node dist/orchestrator.js
         env:
+          RUN_TASK: ingest-logs
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
           TARGET_REPO: ${{ secrets.TARGET_REPO }}

--- a/.github/workflows/agent-review-repo.yml
+++ b/.github/workflows/agent-review-repo.yml
@@ -16,14 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          fetch-depth: 1
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ secrets.TARGET_REPO }}
-          token: ${{ secrets.PAT_TOKEN }}
-          path: target
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
       - name: Ensure lockfile (first run)
@@ -33,24 +25,18 @@ jobs:
           fi
       - run: npm ci --no-audit --no-fund
       - run: npm run build
-      # Run the compiled review script as the single entry point
-      - run: node dist/automation/review-repo.js
+      - run: node dist/orchestrator.js
         env:
+          RUN_TASK: review-repo
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          TARGET_REPO: ${{ secrets.TARGET_REPO }}
+          TARGET_DIR: ${{ secrets.TARGET_DIR }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          TARGET_PATH: target
-          MAX_FILES: "180"
-          MAX_SAMPLED_FILES: "80"
-          MAX_BYTES_PER_FILE: "1500"
-          MAX_INPUT_CHARS: "80000"
-          MAX_OUTPUT_TOKENS: "1200"
-          MAX_TASKS_PER_RUN: 20
-          PROTECTED_PATHS: '["vision.md","roadmap/vision.md"]'
-          PLANNER_MODEL: "gpt-4.1-mini"
-      - name: Commit roadmap & audits to target
-        working-directory: target
-        run: |
-          git config user.name "ai-dev-agent"
-          git config user.email "ai@bot"
-          git add audits/*.md roadmap/*.md 2>/dev/null || true
-          git commit -m "chore(agent): repo review + tasks" || echo "nothing to commit"
-          git push
+          OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
+          AI_BOT_WRITE_MODE: commit
+          DRY_RUN: "0"
+          ALLOW_PATHS: ""

--- a/dist/orchestrator.js
+++ b/dist/orchestrator.js
@@ -1,0 +1,58 @@
+import { ingestLogs } from "./cmds/ingest-logs.js";
+import { reviewRepo } from "./cmds/review-repo.js";
+import { implementTopTask } from "./cmds/implement.js";
+import { loadState } from "./lib/state.js";
+import { getLatestDeployment } from "./lib/vercel.js";
+import { gh, parseRepo } from "./lib/github.js";
+import { ENV } from "./lib/env.js";
+async function shouldIngest(state) {
+    try {
+        const dep = await getLatestDeployment();
+        if (!dep)
+            return false;
+        return dep.createdAt > (state.ingest?.lastDeploymentTimestamp ?? 0);
+    }
+    catch {
+        return false;
+    }
+}
+async function shouldReview(state) {
+    try {
+        if (!ENV.TARGET_REPO)
+            return false;
+        const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+        const resp = await gh().rest.repos.listCommits({ owner, repo, per_page: 1 });
+        const latest = resp.data[0]?.sha;
+        return !!latest && latest !== state.lastReviewedSha;
+    }
+    catch {
+        return false;
+    }
+}
+export async function orchestrate(force) {
+    const state = await loadState();
+    let cmd = force;
+    if (!cmd) {
+        if (await shouldIngest(state))
+            cmd = "ingest-logs";
+        else if (await shouldReview(state))
+            cmd = "review-repo";
+        else
+            cmd = "implement";
+    }
+    if (cmd === "ingest-logs")
+        await ingestLogs();
+    else if (cmd === "review-repo")
+        await reviewRepo();
+    else if (cmd === "implement")
+        await implementTopTask();
+    else {
+        console.error(`Unknown command: ${cmd}`);
+        process.exit(2);
+    }
+}
+const arg = process.argv[2] || process.env.RUN_TASK;
+orchestrate(arg).catch(err => {
+    console.error("[ERROR] orchestrator:", err?.stack || err?.message || err);
+    process.exit(1);
+});

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,0 +1,54 @@
+import { ingestLogs } from "./cmds/ingest-logs.js";
+import { reviewRepo } from "./cmds/review-repo.js";
+import { implementTopTask } from "./cmds/implement.js";
+import { loadState, type AgentState } from "./lib/state.js";
+import { getLatestDeployment } from "./lib/vercel.js";
+import { gh, parseRepo } from "./lib/github.js";
+import { ENV } from "./lib/env.js";
+
+async function shouldIngest(state: AgentState): Promise<boolean> {
+  try {
+    const dep = await getLatestDeployment();
+    if (!dep) return false;
+    return dep.createdAt > (state.ingest?.lastDeploymentTimestamp ?? 0);
+  } catch {
+    return false;
+  }
+}
+
+async function shouldReview(state: AgentState): Promise<boolean> {
+  try {
+    if (!ENV.TARGET_REPO) return false;
+    const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+    const resp = await gh().rest.repos.listCommits({ owner, repo, per_page: 1 });
+    const latest = resp.data[0]?.sha;
+    return !!latest && latest !== state.lastReviewedSha;
+  } catch {
+    return false;
+  }
+}
+
+export async function orchestrate(force?: string) {
+  const state = await loadState();
+  let cmd = force;
+  if (!cmd) {
+    if (await shouldIngest(state)) cmd = "ingest-logs";
+    else if (await shouldReview(state)) cmd = "review-repo";
+    else cmd = "implement";
+  }
+
+  if (cmd === "ingest-logs") await ingestLogs();
+  else if (cmd === "review-repo") await reviewRepo();
+  else if (cmd === "implement") await implementTopTask();
+  else {
+    console.error(`Unknown command: ${cmd}`);
+    process.exit(2);
+  }
+}
+
+const arg = process.argv[2] || process.env.RUN_TASK;
+
+orchestrate(arg).catch(err => {
+  console.error("[ERROR] orchestrator:", err?.stack || err?.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add orchestrator module that selects ingest-logs, review-repo, or implement based on repo state or RUN_TASK override
- route GitHub workflows through new orchestrator instead of direct subcommands

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5d7ee8b6c832a8bb00f21179c3060