### PR TITLE
feat: track agent runtime state

### DIFF
--- a/dist/lib/state.js
+++ b/dist/lib/state.js
@@ -1,9 +1,10 @@
 import { readFile, upsertFile } from "./github.js";
 const STATE_PATH = "agent/STATE.json";
+const LEGACY_STATE_PATH = "roadmap/.state/agent-state.json";
 const CHANGELOG_PATH = "AGENT_CHANGELOG.md";
 const DECISIONS_PATH = "agent/DECISIONS.md";
 export async function loadState() {
-    const raw = await readFile(STATE_PATH);
+    const raw = (await readFile(STATE_PATH)) ?? (await readFile(LEGACY_STATE_PATH));
     if (!raw)
         return {};
     try {

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,5 +1,6 @@
 import { readFile, upsertFile } from "./github.js";
 const STATE_PATH = "agent/STATE.json";
+const LEGACY_STATE_PATH = "roadmap/.state/agent-state.json";
 const CHANGELOG_PATH = "AGENT_CHANGELOG.md";
 const DECISIONS_PATH = "agent/DECISIONS.md";
 
@@ -9,7 +10,7 @@ export type AgentState = {
 };
 
 export async function loadState(): Promise<AgentState> {
-  const raw = await readFile(STATE_PATH);
+  const raw = (await readFile(STATE_PATH)) ?? (await readFile(LEGACY_STATE_PATH));
   if (!raw) return {};
   try { return JSON.parse(raw) as AgentState; } catch { return {}; }
 }


### PR DESCRIPTION
## Summary
- allow reading agent state from legacy roadmap/.state/agent-state.json
- rebuild dist

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5dcc07b18832aae6abc4eb53db0d4