### PR TITLE
feat: run checks before committing

### DIFF
--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -1,4 +1,5 @@
 import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { readFile, commitMany, resolveRepoPath, ensureBranch, getDefaultBranch, upsertFile } from "../lib/github.js";
 import yaml from "js-yaml";
@@ -108,7 +109,10 @@ export async function implementTopTask() {
       const title = plan.commitTitle || ((top.type === "bug" ? "fix" : "feat") + `: ${top.title || top.id}`);
       try {
         execSync("npm run check", { stdio: "inherit" });
-        execSync("npm test", { stdio: "inherit" });
+        const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+        if (pkg?.scripts?.test) {
+          execSync("npm test", { stdio: "inherit" });
+        }
       } catch (err) {
         console.error("Checks or tests failed; aborting commit.", err);
         return;


### PR DESCRIPTION
## Summary
- run `npm run check` before committing
- run `npm test` only when a test script is present

## Testing
- `npm run check`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5dc765cd0832aa7524f38e3d62343