### PR TITLE
fix: consolidate done file update

### DIFF
--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -136,10 +136,8 @@ export async function implementTopTask() {
         return;
       }
       try {
-        await commitMany(files, title, { branch: targetBranch });
+        await commitMany(files, { title, body: commitBody }, { branch: targetBranch });
         await upsertFile("roadmap/tasks.md", () => nextTasks, "bot: remove completed task", { branch: targetBranch });
-        await upsertFile("roadmap/done.md", () => nextDone, "bot: append done item", { branch: targetBranch });
-
         await upsertFile(
           "roadmap/done.md",
           () => nextDone,


### PR DESCRIPTION
## Summary
- pass commit body and title to `commitMany`
- remove duplicate `roadmap/done.md` update and keep single commit with metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b5e0eb794c832ab10ca1b27a433a2b