### PR TITLE
feat: persist state in supabase

### DIFF
--- a/dist/lib/env.js
+++ b/dist/lib/env.js
@@ -13,6 +13,8 @@ export const ENV = {
     DRY_RUN: process.env.DRY_RUN === "1",
     BRANCH: process.env.GITHUB_REF_NAME || process.env.GITHUB_HEAD_REF || "",
     ALLOW_PATHS: (process.env.ALLOW_PATHS || "").split(",").map(s => s.trim()).filter(Boolean),
+    SUPABASE_URL: process.env.SUPABASE_URL || "",
+    SUPABASE_KEY: process.env.SUPABASE_KEY || "",
 };
 // Call this inside commands to assert only what they need.
 export function requireEnv(names) {

--- a/dist/lib/state.js
+++ b/dist/lib/state.js
@@ -1,25 +1,42 @@
-import { readFile, upsertFile } from "./github.js";
-const STATE_PATH = "agent/STATE.json";
-const LEGACY_STATE_PATH = "roadmap/.state/agent-state.json";
-const CHANGELOG_PATH = "AGENT_CHANGELOG.md";
-const DECISIONS_PATH = "agent/DECISIONS.md";
+import { ENV } from "./env.js";
+const { SUPABASE_URL, SUPABASE_KEY } = ENV;
+async function sbRequest(path, init = {}) {
+    if (!SUPABASE_URL || !SUPABASE_KEY)
+        return [];
+    const url = `${SUPABASE_URL}/rest/v1/${path}`;
+    const headers = {
+        apikey: SUPABASE_KEY,
+        Authorization: `Bearer ${SUPABASE_KEY}`,
+        "Content-Type": "application/json",
+        ...init.headers,
+    };
+    const res = await fetch(url, { ...init, headers });
+    if (!res.ok) {
+        throw new Error(`Supabase error: ${res.status} ${res.statusText}`);
+    }
+    return res.json();
+}
 export async function loadState() {
-    const raw = (await readFile(STATE_PATH)) ?? (await readFile(LEGACY_STATE_PATH));
-    if (!raw)
-        return {};
-    try {
-        return JSON.parse(raw);
-    }
-    catch {
-        return {};
-    }
+    const data = (await sbRequest("agent_state?select=data&limit=1"));
+    const row = data[0];
+    return row?.data || {};
 }
 export async function saveState(next) {
-    await upsertFile(STATE_PATH, () => JSON.stringify(next, null, 2) + "\n", "bot: update state");
+    await sbRequest("agent_state", {
+        method: "POST",
+        headers: { Prefer: "resolution=merge-duplicates" },
+        body: JSON.stringify({ id: 1, data: next }),
+    });
 }
 export async function appendChangelog(entry) {
-    await upsertFile(CHANGELOG_PATH, old => (old ?? "") + entry + "\n", "bot: update changelog");
+    await sbRequest("agent_changelog", {
+        method: "POST",
+        body: JSON.stringify({ entry }),
+    });
 }
 export async function appendDecision(entry) {
-    await upsertFile(DECISIONS_PATH, old => (old ?? "") + entry + "\n", "bot: update decisions");
+    await sbRequest("agent_decisions", {
+        method: "POST",
+        body: JSON.stringify({ entry }),
+    });
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -13,6 +13,8 @@ export const ENV = {
   DRY_RUN: process.env.DRY_RUN === "1",
   BRANCH: process.env.GITHUB_REF_NAME || process.env.GITHUB_HEAD_REF || "",
   ALLOW_PATHS: (process.env.ALLOW_PATHS || "").split(",").map(s => s.trim()).filter(Boolean),
+  SUPABASE_URL: process.env.SUPABASE_URL || "",
+  SUPABASE_KEY: process.env.SUPABASE_KEY || "",
 };
 
 // Call this inside commands to assert only what they need.

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,8 +1,22 @@
-import { readFile, upsertFile } from "./github.js";
-const STATE_PATH = "agent/STATE.json";
-const LEGACY_STATE_PATH = "roadmap/.state/agent-state.json";
-const CHANGELOG_PATH = "AGENT_CHANGELOG.md";
-const DECISIONS_PATH = "agent/DECISIONS.md";
+import { ENV } from "./env.js";
+
+const { SUPABASE_URL, SUPABASE_KEY } = ENV;
+
+async function sbRequest(path: string, init: RequestInit = {}) {
+  if (!SUPABASE_URL || !SUPABASE_KEY) return [];
+  const url = `${SUPABASE_URL}/rest/v1/${path}`;
+  const headers: Record<string, string> = {
+    apikey: SUPABASE_KEY,
+    Authorization: `Bearer ${SUPABASE_KEY}`,
+    "Content-Type": "application/json",
+    ...(init.headers as Record<string, string>),
+  };
+  const res = await fetch(url, { ...init, headers });
+  if (!res.ok) {
+    throw new Error(`Supabase error: ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
 
 export type AgentState = {
   ingest?: { lastDeploymentTimestamp?: number; lastRowIds?: string[] };
@@ -10,27 +24,29 @@ export type AgentState = {
 };
 
 export async function loadState(): Promise<AgentState> {
-  const raw = (await readFile(STATE_PATH)) ?? (await readFile(LEGACY_STATE_PATH));
-  if (!raw) return {};
-  try { return JSON.parse(raw) as AgentState; } catch { return {}; }
+  const data = (await sbRequest("agent_state?select=data&limit=1")) as any[];
+  const row = data[0];
+  return (row?.data as AgentState) || {};
 }
 
 export async function saveState(next: AgentState) {
-  await upsertFile(STATE_PATH, () => JSON.stringify(next, null, 2) + "\n", "bot: update state");
+  await sbRequest("agent_state", {
+    method: "POST",
+    headers: { Prefer: "resolution=merge-duplicates" },
+    body: JSON.stringify({ id: 1, data: next }),
+  });
 }
 
 export async function appendChangelog(entry: string) {
-  await upsertFile(
-    CHANGELOG_PATH,
-    old => (old ?? "") + entry + "\n",
-    "bot: update changelog"
-  );
+  await sbRequest("agent_changelog", {
+    method: "POST",
+    body: JSON.stringify({ entry }),
+  });
 }
 
 export async function appendDecision(entry: string) {
-  await upsertFile(
-    DECISIONS_PATH,
-    old => (old ?? "") + entry + "\n",
-    "bot: update decisions"
-  );
+  await sbRequest("agent_decisions", {
+    method: "POST",
+    body: JSON.stringify({ entry }),
+  });
 }


### PR DESCRIPTION
## Summary
- replace file-backed agent state with Supabase tables
- insert changelog and decision entries into Supabase instead of committing files
- expose Supabase URL and key via ENV

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b5eb0bc114832abd1201da826a330c