### PR TITLE
fix: require Supabase env only when client is used

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -26,4 +26,4 @@ export function requireEnv(names: string[]) {
   }
 }
 
-requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+// Avoid requiring SUPABASE variables for commands that don't need them.

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
-import { ENV } from "./env.js";
+import { ENV, requireEnv } from "./env.js";
 
+requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
 export const supabase = createClient(ENV.SUPABASE_URL, ENV.SUPABASE_SERVICE_ROLE_KEY);


### PR DESCRIPTION
## Summary
- stop env module from forcing SUPABASE env vars
- validate SUPABASE env vars within supabase client module

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b5ecdb4fcc832ab390ab53d0719234