### PR TITLE
fix: handle Supabase write errors

### DIFF
--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -119,14 +119,26 @@ export async function implementTopTask() {
       try {
         await commitMany(files, { title, body: commitBody }, { branch: targetBranch });
 
-        await supabase.from("tasks").update({ status: "done", type: "done" }).eq("id", top.id);
-        await supabase.from("tasks").insert({
+        const { error: updateError } = await supabase
+          .from("tasks")
+          .update({ status: "done", type: "done" })
+          .eq("id", top.id);
+        if (updateError) {
+          console.error("Failed to update task status", updateError);
+          return;
+        }
+
+        const { error: insertError } = await supabase.from("tasks").insert({
           title: top.title,
           desc: top.desc,
           type: "done",
           priority: top.priority,
           parent: top.id,
         });
+        if (insertError) {
+          console.error("Failed to insert completed task record", insertError);
+          return;
+        }
 
         console.log("Implement complete.");
       } catch (err) {


### PR DESCRIPTION
## Summary
- handle Supabase task update/insert errors after commit to ensure task state changes are surfaced

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b5ed9895ac832ab2edd096eda5ca57