### PR TITLE
fix: fallback to file store when Supabase missing

### DIFF
--- a/dist/lib/state.js
+++ b/dist/lib/state.js
@@ -1,8 +1,15 @@
 import { ENV } from "./env.js";
+import { readFile, upsertFile } from "./github.js";
 const { SUPABASE_URL, SUPABASE_KEY } = ENV;
+const HAS_SUPABASE = !!SUPABASE_URL && !!SUPABASE_KEY;
+const STATE_PATH = "agent/STATE.json";
+const LEGACY_STATE_PATH = "roadmap/.state/agent-state.json";
+const CHANGELOG_PATH = "AGENT_CHANGELOG.md";
+const DECISIONS_PATH = "agent/DECISIONS.md";
 async function sbRequest(path, init = {}) {
-    if (!SUPABASE_URL || !SUPABASE_KEY)
-        return [];
+    if (!HAS_SUPABASE) {
+        throw new Error("Missing Supabase credentials");
+    }
     const url = `${SUPABASE_URL}/rest/v1/${path}`;
     const headers = {
         apikey: SUPABASE_KEY,
@@ -17,11 +24,26 @@ async function sbRequest(path, init = {}) {
     return res.json();
 }
 export async function loadState() {
+    if (!HAS_SUPABASE) {
+        const raw = (await readFile(STATE_PATH)) ?? (await readFile(LEGACY_STATE_PATH));
+        if (!raw)
+            return {};
+        try {
+            return JSON.parse(raw);
+        }
+        catch {
+            return {};
+        }
+    }
     const data = (await sbRequest("agent_state?select=data&limit=1"));
     const row = data[0];
     return row?.data || {};
 }
 export async function saveState(next) {
+    if (!HAS_SUPABASE) {
+        await upsertFile(STATE_PATH, () => JSON.stringify(next, null, 2) + "\n", "bot: update state");
+        return;
+    }
     await sbRequest("agent_state", {
         method: "POST",
         headers: { Prefer: "resolution=merge-duplicates" },
@@ -29,12 +51,20 @@ export async function saveState(next) {
     });
 }
 export async function appendChangelog(entry) {
+    if (!HAS_SUPABASE) {
+        await upsertFile(CHANGELOG_PATH, old => (old ?? "") + entry + "\n", "bot: update changelog");
+        return;
+    }
     await sbRequest("agent_changelog", {
         method: "POST",
         body: JSON.stringify({ entry }),
     });
 }
 export async function appendDecision(entry) {
+    if (!HAS_SUPABASE) {
+        await upsertFile(DECISIONS_PATH, old => (old ?? "") + entry + "\n", "bot: update decisions");
+        return;
+    }
     await sbRequest("agent_decisions", {
         method: "POST",
         body: JSON.stringify({ entry }),

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,12 +1,21 @@
 import { ENV } from "./env.js";
+import { readFile, upsertFile } from "./github.js";
 
 const { SUPABASE_URL, SUPABASE_KEY } = ENV;
+const HAS_SUPABASE = !!SUPABASE_URL && !!SUPABASE_KEY;
+
+const STATE_PATH = "agent/STATE.json";
+const LEGACY_STATE_PATH = "roadmap/.state/agent-state.json";
+const CHANGELOG_PATH = "AGENT_CHANGELOG.md";
+const DECISIONS_PATH = "agent/DECISIONS.md";
 
 async function sbRequest(path: string, init: RequestInit = {}) {
-  if (!SUPABASE_URL || !SUPABASE_KEY) return [];
+  if (!HAS_SUPABASE) {
+    throw new Error("Missing Supabase credentials");
+  }
   const url = `${SUPABASE_URL}/rest/v1/${path}`;
   const headers: Record<string, string> = {
-    apikey: SUPABASE_KEY,
+    apikey: SUPABASE_KEY!,
     Authorization: `Bearer ${SUPABASE_KEY}`,
     "Content-Type": "application/json",
     ...(init.headers as Record<string, string>),
@@ -24,12 +33,29 @@ export type AgentState = {
 };
 
 export async function loadState(): Promise<AgentState> {
+  if (!HAS_SUPABASE) {
+    const raw = (await readFile(STATE_PATH)) ?? (await readFile(LEGACY_STATE_PATH));
+    if (!raw) return {};
+    try {
+      return JSON.parse(raw) as AgentState;
+    } catch {
+      return {};
+    }
+  }
   const data = (await sbRequest("agent_state?select=data&limit=1")) as any[];
   const row = data[0];
   return (row?.data as AgentState) || {};
 }
 
 export async function saveState(next: AgentState) {
+  if (!HAS_SUPABASE) {
+    await upsertFile(
+      STATE_PATH,
+      () => JSON.stringify(next, null, 2) + "\n",
+      "bot: update state"
+    );
+    return;
+  }
   await sbRequest("agent_state", {
     method: "POST",
     headers: { Prefer: "resolution=merge-duplicates" },
@@ -38,6 +64,14 @@ export async function saveState(next: AgentState) {
 }
 
 export async function appendChangelog(entry: string) {
+  if (!HAS_SUPABASE) {
+    await upsertFile(
+      CHANGELOG_PATH,
+      old => (old ?? "") + entry + "\n",
+      "bot: update changelog"
+    );
+    return;
+  }
   await sbRequest("agent_changelog", {
     method: "POST",
     body: JSON.stringify({ entry }),
@@ -45,6 +79,14 @@ export async function appendChangelog(entry: string) {
 }
 
 export async function appendDecision(entry: string) {
+  if (!HAS_SUPABASE) {
+    await upsertFile(
+      DECISIONS_PATH,
+      old => (old ?? "") + entry + "\n",
+      "bot: update decisions"
+    );
+    return;
+  }
   await sbRequest("agent_decisions", {
     method: "POST",
     body: JSON.stringify({ entry }),


### PR DESCRIPTION
## Summary
- guard against absent Supabase credentials
- fall back to file-backed state, changelog, and decisions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b5f318685c832abd7087ef67b55d12