### PR TITLE
Use Supabase service role key for task synthesis

### DIFF
--- a/src/cmds/synthesize-tasks.ts
+++ b/src/cmds/synthesize-tasks.ts
@@ -14,12 +14,12 @@ function isMeta(t: Task) { return /batch task synthesis/i.test(t?.title || "") |
 export async function synthesizeTasks() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
-    requireEnv(["SUPABASE_URL", "SUPABASE_KEY"]);
+    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
 
     const vision = (await readFile("roadmap/vision.md")) || "";
     const doneMd  = (await readFile("roadmap/done.md"))  || "";
 
-    const headers = { apikey: ENV.SUPABASE_KEY, Authorization: `Bearer ${ENV.SUPABASE_KEY}` };
+    const headers = { apikey: ENV.SUPABASE_SERVICE_ROLE_KEY, Authorization: `Bearer ${ENV.SUPABASE_SERVICE_ROLE_KEY}` };
     const url = ENV.SUPABASE_URL;
     const res = await fetch(`${url}/rest/v1/roadmap_items?select=*`, { headers });
     if (!res.ok) throw new Error(`Supabase fetch failed: ${res.status}`);


### PR DESCRIPTION
## Summary
- require Supabase service role key for task synthesis
- pass service role key in Supabase REST headers

## Testing
- `npm run build` *(fails: Property 'SUPABASE_KEY' does not exist on type...)*
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b5f6b3ef6c832a96fb472a55312c9c