### PR TITLE
refactor: use service role key for supabase client

### DIFF
--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -11,8 +11,8 @@ type Task = { id?: string; title?: string; desc?: string; type?: string; priorit
 export async function implementTopTask() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
-    requireEnv(["SUPABASE_URL", "SUPABASE_KEY"]);
-    const supabase = createClient(ENV.SUPABASE_URL, ENV.SUPABASE_KEY);
+    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+    const supabase = createClient(ENV.SUPABASE_URL, ENV.SUPABASE_SERVICE_ROLE_KEY);
 
     // Load vision for context
     const vision = (await readFile("roadmap/vision.md")) || "";


### PR DESCRIPTION
## Summary
- use `SUPABASE_SERVICE_ROLE_KEY` instead of `SUPABASE_KEY` in implement command
- rebuild compiled `implement.js`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b5f6b57d68832ab9a7923ef1a78676