### PR TITLE
Use service role key for Supabase state

### DIFF
--- a/dist/lib/state.js
+++ b/dist/lib/state.js
@@ -1,7 +1,7 @@
 import { ENV } from "./env.js";
 import { readFile, upsertFile } from "./github.js";
-const { SUPABASE_URL, SUPABASE_KEY } = ENV;
-const HAS_SUPABASE = !!SUPABASE_URL && !!SUPABASE_KEY;
+const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = ENV;
+const HAS_SUPABASE = !!SUPABASE_URL && !!SUPABASE_SERVICE_ROLE_KEY;
 const STATE_PATH = "agent/STATE.json";
 const LEGACY_STATE_PATH = "roadmap/.state/agent-state.json";
 const CHANGELOG_PATH = "AGENT_CHANGELOG.md";
@@ -12,8 +12,8 @@ async function sbRequest(path, init = {}) {
     }
     const url = `${SUPABASE_URL}/rest/v1/${path}`;
     const headers = {
-        apikey: SUPABASE_KEY,
-        Authorization: `Bearer ${SUPABASE_KEY}`,
+        apikey: SUPABASE_SERVICE_ROLE_KEY,
+        Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
         "Content-Type": "application/json",
         ...init.headers,
     };

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,8 +1,8 @@
 import { ENV } from "./env.js";
 import { readFile, upsertFile } from "./github.js";
 
-const { SUPABASE_URL, SUPABASE_KEY } = ENV;
-const HAS_SUPABASE = !!SUPABASE_URL && !!SUPABASE_KEY;
+const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = ENV;
+const HAS_SUPABASE = !!SUPABASE_URL && !!SUPABASE_SERVICE_ROLE_KEY;
 
 const STATE_PATH = "agent/STATE.json";
 const LEGACY_STATE_PATH = "roadmap/.state/agent-state.json";
@@ -15,8 +15,8 @@ async function sbRequest(path: string, init: RequestInit = {}) {
   }
   const url = `${SUPABASE_URL}/rest/v1/${path}`;
   const headers: Record<string, string> = {
-    apikey: SUPABASE_KEY!,
-    Authorization: `Bearer ${SUPABASE_KEY}`,
+    apikey: SUPABASE_SERVICE_ROLE_KEY!,
+    Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
     "Content-Type": "application/json",
     ...(init.headers as Record<string, string>),
   };


### PR DESCRIPTION
## Summary
- Replace `SUPABASE_KEY` usage with `SUPABASE_SERVICE_ROLE_KEY` in state management
- Rebuild compiled state module

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`
- `npm run build` *(fails: Cannot find module '@supabase/supabase-js' and missing `SUPABASE_KEY` references)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f6b91de4832abd5f61c2dd718855