### PR TITLE
fix: require Supabase key for state helpers

### DIFF
--- a/dist/cmds/review-repo.js
+++ b/dist/cmds/review-repo.js
@@ -10,7 +10,7 @@ export async function reviewRepo() {
         return;
     }
     try {
-        requireEnv(["TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+        requireEnv(["TARGET_REPO", "SUPABASE_URL", "SUPABASE_KEY", "SUPABASE_SERVICE_ROLE_KEY"]);
         async function fetchRoadmap(type) {
             const url = `${process.env.SUPABASE_URL}/rest/v1/roadmap_items?select=content&type=eq.${type}`;
             const resp = await fetch(url, {

--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -8,7 +8,7 @@ import yaml from "js-yaml";
 export async function reviewRepo() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
-    requireEnv(["TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+    requireEnv(["TARGET_REPO", "SUPABASE_URL", "SUPABASE_KEY", "SUPABASE_SERVICE_ROLE_KEY"]);
     async function fetchRoadmap(type: string) {
       const url = `${process.env.SUPABASE_URL}/rest/v1/roadmap_items?select=content&type=eq.${type}`;
       const resp = await fetch(url, {


### PR DESCRIPTION
## Summary
- also require `SUPABASE_KEY` so downstream helpers keep using Supabase

## Testing
- `npm run build` *(fails: Cannot find module '@supabase/supabase-js' ...)*
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b5f861abb8832abcf7bb3b4c07b36a