### PR TITLE
fix: make roadmap migration idempotent

### DIFF
--- a/dist/lib/roadmap.js
+++ b/dist/lib/roadmap.js
@@ -4,3 +4,10 @@ export async function insertRoadmap(items) {
     if (error)
         throw error;
 }
+export async function upsertRoadmap(items) {
+    const { error } = await supabase
+        .from("roadmap")
+        .upsert(items, { onConflict: "id" });
+    if (error)
+        throw error;
+}

--- a/scripts/migrate-roadmap.ts
+++ b/scripts/migrate-roadmap.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
-import { randomUUID } from "node:crypto";
-import { insertRoadmap, type RoadmapItem } from "../src/lib/roadmap.js";
+import { createHash } from "node:crypto";
+import { upsertRoadmap, type RoadmapItem } from "../src/lib/roadmap.js";
 import { readYamlBlock } from "../src/lib/md.js";
 
 type Task = {
@@ -44,13 +44,18 @@ async function main() {
     return;
   }
   const items: RoadmapItem[] = tasks.map(t => ({
-    id: t.id ?? randomUUID(),
+    id:
+      t.id ||
+      createHash("sha1")
+        .update(t.title ?? "")
+        .update(t.desc ?? "")
+        .digest("hex"),
     type: t.type === "bug" ? "bug" : "idea",
     title: t.title ?? "",
     details: t.desc ?? "",
     created: t.created ?? new Date().toISOString(),
   }));
-  await insertRoadmap(items);
+  await upsertRoadmap(items);
   console.log(`Migrated ${items.length} tasks to Supabase.`);
 }
 

--- a/src/lib/roadmap.ts
+++ b/src/lib/roadmap.ts
@@ -13,3 +13,10 @@ export async function insertRoadmap(items: RoadmapItem[]) {
   if (error) throw error;
 }
 
+export async function upsertRoadmap(items: RoadmapItem[]) {
+  const { error } = await supabase
+    .from("roadmap")
+    .upsert(items, { onConflict: "id" });
+  if (error) throw error;
+}
+


### PR DESCRIPTION
## Summary
- generate deterministic IDs for roadmap items lacking an id
- add upsertRoadmap helper and use it in migration script

## Testing
- `npm run build`
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b60edb37c0832ab3983ecf19e2ad4e