### PR TITLE
feat: single commit for batch files

### DIFF
--- a/dist/lib/github.js
+++ b/dist/lib/github.js
@@ -104,24 +104,59 @@ export async function upsertFile(path, updater, message, opts) {
 export async function commitMany(files, message, opts) {
     const { owner, repo } = parseRepo(ENV.TARGET_REPO);
     const ref = opts?.branch;
+    const msg = formatMessage(message);
     if (ENV.DRY_RUN) {
-        const msg = formatMessage(message);
-        console.log(`[DRY_RUN] commitMany ${files.length} files on ${ref || "(default branch)"}: ${msg}`);
+        console.log(`[DRY_RUN] commitMany will create 1 commit on ${ref || "(default branch)"}: ${msg}`);
+        for (const f of files) {
+            const safePath = resolveRepoPath(f.path);
+            console.log(`  - ${safePath} (${f.content.length} bytes)`);
+        }
         return;
     }
+    const branch = ref || (await getDefaultBranch());
+    const git = gh().rest.git;
+    const headRef = await git.getRef({ owner, repo, ref: `heads/${branch}` });
+    const latestCommitSha = headRef.data.object.sha;
+    const latestCommit = await git.getCommit({
+        owner,
+        repo,
+        commit_sha: latestCommitSha
+    });
+    const treeEntries = [];
     for (const f of files) {
         const safePath = resolveRepoPath(f.path);
-        const { sha } = await getFile(owner, repo, safePath, ref);
-        await gh().rest.repos.createOrUpdateFileContents({
+        const blob = await git.createBlob({
             owner,
             repo,
+            content: f.content,
+            encoding: "utf-8"
+        });
+        treeEntries.push({
             path: safePath,
-            message: formatMessage(message),
-            content: b64(f.content),
-            sha,
-            ...(ref ? { branch: ref } : {}),
-            committer: { name: "ai-dev-agent", email: "bot@local" },
-            author: { name: "ai-dev-agent", email: "bot@local" }
+            mode: "100644",
+            type: "blob",
+            sha: blob.data.sha
         });
     }
+    const tree = await git.createTree({
+        owner,
+        repo,
+        base_tree: latestCommit.data.tree.sha,
+        tree: treeEntries
+    });
+    const newCommit = await git.createCommit({
+        owner,
+        repo,
+        message: msg,
+        tree: tree.data.sha,
+        parents: [latestCommitSha],
+        committer: { name: "ai-dev-agent", email: "bot@local" },
+        author: { name: "ai-dev-agent", email: "bot@local" }
+    });
+    await git.updateRef({
+        owner,
+        repo,
+        ref: `heads/${branch}`,
+        sha: newCommit.data.sha
+    });
 }


### PR DESCRIPTION
## Summary
- Build a tree for all file updates and commit once in `commitMany`
- Log dry-run details to confirm a single commit handles multiple files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`
- `node dist/lib/github.js` dry-run for multiple files

------
https://chatgpt.com/codex/tasks/task_e_68b610cec25c832a87f7992c2a9ad4f7