### PR TITLE
Handle empty Supabase responses in sbRequest

### DIFF
--- a/dist/lib/state.js
+++ b/dist/lib/state.js
@@ -18,11 +18,14 @@ async function sbRequest(path, init = {}) {
     if (!res.ok) {
         throw new Error(`Supabase error: ${res.status} ${res.statusText}`);
     }
+    if (res.status === 204 || res.headers.get("Content-Length") === "0") {
+        return undefined;
+    }
     return res.json();
 }
 export async function loadState() {
     const data = (await sbRequest("agent_state?select=data&limit=1"));
-    const row = data[0];
+    const row = data?.[0];
     return row?.data || {};
 }
 export async function saveState(next) {

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -23,6 +23,9 @@ async function sbRequest(path: string, init: RequestInit = {}) {
   if (!res.ok) {
     throw new Error(`Supabase error: ${res.status} ${res.statusText}`);
   }
+  if (res.status === 204 || res.headers.get("Content-Length") === "0") {
+    return undefined;
+  }
   return res.json();
 }
 
@@ -32,8 +35,8 @@ export type AgentState = {
 };
 
 export async function loadState(): Promise<AgentState> {
-  const data = (await sbRequest("agent_state?select=data&limit=1")) as any[];
-  const row = data[0];
+  const data = (await sbRequest("agent_state?select=data&limit=1")) as any[] | undefined;
+  const row = data?.[0];
   return (row?.data as AgentState) || {};
 }
 


### PR DESCRIPTION
## Summary
- return undefined for Supabase responses with no content
- guard state loading against missing response bodies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b616410a9c832aa340bc6bb6517da2