### PR TITLE
refactor: use shared supabase client

### DIFF
--- a/src/cmds/normalize-roadmap.ts
+++ b/src/cmds/normalize-roadmap.ts
@@ -1,7 +1,7 @@
-import { createClient } from "@supabase/supabase-js";
 import yaml from "js-yaml";
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { upsertFile } from "../lib/github.js";
+import { supabase } from "../lib/supabase.js";
 
 type Task = {
   id?: string;
@@ -23,9 +23,6 @@ function isMeta(t: Task) {
 export async function normalizeRoadmap() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
-    const supabaseUrl = process.env.SUPABASE_URL!;
-    const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-    const supabase = createClient(supabaseUrl, supabaseKey);
     const { data, error } = await supabase.from("tasks").select("*");
     if (error) throw error;
     let items = (data || []) as Task[];


### PR DESCRIPTION
## Summary
- use shared supabase client in normalize-roadmap
- use shared supabase client in implement

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b618e57994832ab928207d5104ea03