### PR TITLE
fix: lazily create Supabase client

### DIFF
--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -4,13 +4,13 @@ import { acquireLock, releaseLock } from "../lib/lock.js";
 import { readFile, commitMany, resolveRepoPath, ensureBranch, getDefaultBranch } from "../lib/github.js";
 import { implementPlan } from "../lib/prompts.js";
 import { ENV } from "../lib/env.js";
-import { supabase } from "../lib/supabase.js";
 
 type Task = { id?: string; title?: string; desc?: string; type?: string; priority?: number };
 
 export async function implementTopTask() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
+    const { supabase } = await import("../lib/supabase.js");
     // Load vision for context
     const vision = (await readFile("roadmap/vision.md")) || "";
 

--- a/src/cmds/normalize-roadmap.ts
+++ b/src/cmds/normalize-roadmap.ts
@@ -1,7 +1,6 @@
 import yaml from "js-yaml";
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { upsertFile } from "../lib/github.js";
-import { supabase } from "../lib/supabase.js";
 
 type Task = {
   id?: string;
@@ -23,6 +22,7 @@ function isMeta(t: Task) {
 export async function normalizeRoadmap() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
+    const { supabase } = await import("../lib/supabase.js");
     const { data, error } = await supabase.from("tasks").select("*");
     if (error) throw error;
     let items = (data || []) as Task[];


### PR DESCRIPTION
## Summary
- import Supabase client lazily inside CLI commands
- avoid requiring Supabase env for commands that don't use it

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b619e66c30832aa0aa80f298b3678c