### PR TITLE
refactor: centralize task interface

### DIFF
--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -4,8 +4,7 @@ import { acquireLock, releaseLock } from "../lib/lock.js";
 import { readFile, commitMany, resolveRepoPath, ensureBranch, getDefaultBranch } from "../lib/github.js";
 import { implementPlan } from "../lib/prompts.js";
 import { ENV } from "../lib/env.js";
-
-type Task = { id?: string; title?: string; desc?: string; type?: string; priority?: number };
+import type { Task } from "../lib/types.js";
 
 export async function implementTopTask() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }

--- a/src/cmds/normalize-roadmap.ts
+++ b/src/cmds/normalize-roadmap.ts
@@ -1,16 +1,7 @@
 import yaml from "js-yaml";
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { upsertFile } from "../lib/github.js";
-
-type Task = {
-  id?: string;
-  type?: "bug" | "improvement" | "feature" | string;
-  title?: string;
-  desc?: string;
-  source?: string;
-  created?: string;
-  priority?: number;
-};
+import type { Task } from "../lib/types.js";
 
 function normTitle(t = "") {
   return t.toLowerCase().replace(/\s+/g, " ").replace(/[`"'*]/g, "").trim();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,10 @@
+export interface Task {
+  id?: string;
+  type?: "bug" | "improvement" | "feature" | string;
+  title?: string;
+  desc?: string;
+  source?: string;
+  created?: string;
+  priority?: number;
+}
+


### PR DESCRIPTION
## Summary
- add shared `Task` interface
- use `Task` from shared types in commands

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b61b84ed30832a9c61cb75f8471a09