### PR TITLE
refactor: use ENV for Supabase config in roadmap normalization

### DIFF
--- a/dist/cmds/normalize-roadmap.js
+++ b/dist/cmds/normalize-roadmap.js
@@ -2,6 +2,7 @@ import { createClient } from "@supabase/supabase-js";
 import yaml from "js-yaml";
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { upsertFile } from "../lib/github.js";
+import { ENV } from "../lib/env.js";
 function normTitle(t = "") {
     return t.toLowerCase().replace(/\s+/g, " ").replace(/[`"'*]/g, "").trim();
 }
@@ -14,9 +15,7 @@ export async function normalizeRoadmap() {
         return;
     }
     try {
-        const supabaseUrl = process.env.SUPABASE_URL;
-        const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-        const supabase = createClient(supabaseUrl, supabaseKey);
+        const supabase = createClient(ENV.SUPABASE_URL, ENV.SUPABASE_SERVICE_ROLE_KEY);
         const { data, error } = await supabase.from("tasks").select("*");
         if (error)
             throw error;

--- a/src/cmds/normalize-roadmap.ts
+++ b/src/cmds/normalize-roadmap.ts
@@ -1,7 +1,9 @@
 import yaml from "js-yaml";
+import { createClient } from "@supabase/supabase-js";
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { upsertFile } from "../lib/github.js";
 import type { Task } from "../lib/types.js";
+import { ENV } from "../lib/env.js";
 
 function normTitle(t = "") {
   return t.toLowerCase().replace(/\s+/g, " ").replace(/[`"'*]/g, "").trim();
@@ -13,7 +15,7 @@ function isMeta(t: Task) {
 export async function normalizeRoadmap() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
-    const { supabase } = await import("../lib/supabase.js");
+    const supabase = createClient(ENV.SUPABASE_URL, ENV.SUPABASE_SERVICE_ROLE_KEY);
     const { data, error } = await supabase.from("tasks").select("*");
     if (error) throw error;
     let items = (data || []) as Task[];


### PR DESCRIPTION
## Summary
- create Supabase client in normalize-roadmap using ENV variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b61ce2fa48832ab0ae09466a4aacfd