### PR TITLE
feat: add atomic task completion helper

### DIFF
--- a/dist/lib/tasks.js
+++ b/dist/lib/tasks.js
@@ -1,0 +1,15 @@
+import { supabase } from "./supabase.js";
+/**
+ * Marks a task as completed and logs the completion in a single operation.
+ * Uses a stored procedure or upsert to ensure both actions occur atomically.
+ */
+export async function completeTask(task) {
+    const { error } = await supabase.rpc("complete_task", {
+        task_id: task.id,
+        title: task.title,
+        desc: task.desc,
+        priority: task.priority,
+    });
+    if (error)
+        throw error;
+}

--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -4,6 +4,7 @@ import { acquireLock, releaseLock } from "../lib/lock.js";
 import { readFile, commitMany, resolveRepoPath, ensureBranch, getDefaultBranch } from "../lib/github.js";
 import { implementPlan } from "../lib/prompts.js";
 import { ENV } from "../lib/env.js";
+import { completeTask } from "../lib/tasks.js";
 import type { Task } from "../lib/types.js";
 
 export async function implementTopTask() {
@@ -88,7 +89,7 @@ export async function implementTopTask() {
       const scope = cb.scope || files.map(f => f.path).join(", ");
       const validation = cb.validation || plan.testHint || "n/a";
       const logLink = cb.logUrl || cb.logs || cb.log || undefined;
-      const taskLink = cb.taskUrl || cb.task || (top.id ? `${supabase.supabaseUrl}/rest/v1/tasks?id=eq.${top.id}` : undefined);
+      const taskLink = cb.taskUrl || cb.task || (top.id ? `${ENV.SUPABASE_URL}/rest/v1/tasks?id=eq.${top.id}` : undefined);
       const bodyParts = [
         `Root Cause: ${rootCause}`,
         `Scope: ${scope}`,
@@ -118,28 +119,7 @@ export async function implementTopTask() {
       }
       try {
         await commitMany(files, { title, body: commitBody }, { branch: targetBranch });
-
-        const { error: updateError } = await supabase
-          .from("tasks")
-          .update({ status: "done", type: "done" })
-          .eq("id", top.id);
-        if (updateError) {
-          console.error("Failed to update task status", updateError);
-          return;
-        }
-
-        const { error: insertError } = await supabase.from("tasks").insert({
-          title: top.title,
-          desc: top.desc,
-          type: "done",
-          priority: top.priority,
-          parent: top.id,
-        });
-        if (insertError) {
-          console.error("Failed to insert completed task record", insertError);
-          return;
-        }
-
+        await completeTask(top);
         console.log("Implement complete.");
       } catch (err) {
         console.error("Bulk commit failed; no changes were applied.", err);

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -1,0 +1,17 @@
+import { supabase } from "./supabase.js";
+import type { Task } from "./types.js";
+
+/**
+ * Marks a task as completed and logs the completion in a single operation.
+ * Uses a stored procedure or upsert to ensure both actions occur atomically.
+ */
+export async function completeTask(task: Task) {
+  const { error } = await supabase.rpc("complete_task", {
+    task_id: task.id,
+    title: task.title,
+    desc: task.desc,
+    priority: task.priority,
+  });
+  if (error) throw error;
+}
+


### PR DESCRIPTION
## Summary
- add `completeTask` helper to mark tasks done and log completion in a single RPC call
- use the new helper in `implementTopTask` instead of separate updates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b61fc94cd8832a8018f7fe95634a2d