### PR TITLE
feat: add atomic task completion helper

### DIFF
--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -4,7 +4,6 @@ import { acquireLock, releaseLock } from "../lib/lock.js";
 import { readFile, commitMany, resolveRepoPath, ensureBranch, getDefaultBranch } from "../lib/github.js";
 import { implementPlan } from "../lib/prompts.js";
 import { ENV } from "../lib/env.js";
-import { completeTask } from "../lib/tasks.js";
 import type { Task } from "../lib/types.js";
 
 export async function implementTopTask() {
@@ -119,6 +118,7 @@ export async function implementTopTask() {
       }
       try {
         await commitMany(files, { title, body: commitBody }, { branch: targetBranch });
+        const { completeTask } = await import("../lib/tasks.js");
         await completeTask(top);
         console.log("Implement complete.");
       } catch (err) {


### PR DESCRIPTION
## Summary
- add `completeTask` helper to mark tasks done and log completion in a single RPC call
- use the new helper in `implementTopTask` instead of separate updates
- defer `completeTask` import so unrelated CLI commands don't require Supabase env vars at startup

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b6212ba6d4832ab243a40af4efcbf9