### PR TITLE
fix: validate fallback path with ALLOW_PATHS

### DIFF
--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -67,11 +67,19 @@ export async function implementTopTask() {
 
     if (!filtered.length) {
       // Fallback: create a minimal test placeholder if none proposed
-      filtered.push({
+      const fallback = {
         path: "TASK_NOTES.md",
-        action: "update",
+        action: "update" as const,
         content: `- ${new Date().toISOString()} Implemented: ${top.title}\n`
-      });
+      };
+      if (ENV.ALLOW_PATHS.length) {
+        const allows = ENV.ALLOW_PATHS.map(a => a.replace(/^\/+/, "").replace(/^\.\//, ""));
+        if (!allows.some(allow => fallback.path.startsWith(allow))) {
+          console.error("Fallback path TASK_NOTES.md is not permitted by ALLOW_PATHS; aborting.");
+          return;
+        }
+      }
+      filtered.push(fallback);
     }
 
     // Build file list from normalized ops


### PR DESCRIPTION
## Summary
- re-check ALLOW_PATHS before adding fallback `TASK_NOTES.md`

## Testing
- `npm run check`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b623b0f8c4832aa9adeb94708ad326