### PR TITLE
feat: require TARGET_REPO for task synthesis

### DIFF
--- a/src/cmds/synthesize-tasks.ts
+++ b/src/cmds/synthesize-tasks.ts
@@ -14,7 +14,14 @@ function isMeta(t: Task) { return /batch task synthesis/i.test(t?.title || "") |
 export async function synthesizeTasks() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
-    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+    try {
+      requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "TARGET_REPO"]);
+    } catch (err) {
+      if (err instanceof Error && err.message.includes("TARGET_REPO")) {
+        throw new Error("Missing env: TARGET_REPO. Set TARGET_REPO before running this command.");
+      }
+      throw err;
+    }
 
     const vision = (await readFile("roadmap/vision.md")) || "";
     const doneMd  = (await readFile("roadmap/done.md"))  || "";


### PR DESCRIPTION
## Summary
- ensure `synthesize-tasks` checks for `TARGET_REPO`
- guide users to set `TARGET_REPO` when missing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b623e58a1c832ab8460a416cae323a