### PR TITLE
feat: default planner model with fallback

### DIFF
--- a/dist/automation/prompt.js
+++ b/dist/automation/prompt.js
@@ -6,10 +6,22 @@ function requireEnv(names) {
         }
     }
 }
+async function resolveModel(client) {
+    const defaultModel = "gpt-4o-mini";
+    const preferred = process.env.PLANNER_MODEL || defaultModel;
+    try {
+        await client.models.retrieve(preferred);
+        return preferred;
+    }
+    catch (err) {
+        console.warn(`Falling back to ${defaultModel} due to`, err);
+        return defaultModel;
+    }
+}
 export async function planRepo(input) {
     requireEnv(["OPENAI_API_KEY"]);
     const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-    const model = process.env.PLANNER_MODEL || "gpt-5";
+    const model = await resolveModel(client);
     const maxTokens = Number(process.env.MAX_TOKENS || process.env.MAX_OUTPUT_TOKENS || 1200);
     const system = [
         "You are an agnostic, milestone-driven project planner.",


### PR DESCRIPTION
## Summary
- regenerate compiled automation prompt bundle so runtime model fallback is shipped

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b6894a0490832aa9aa4cc5229df04e