### PR TITLE
Handle invalid PROTECTED_PATHS env var

### DIFF
--- a/automation/review-repo.ts
+++ b/automation/review-repo.ts
@@ -13,8 +13,8 @@ let PROTECTED_PATHS: string[];
 try {
   PROTECTED_PATHS = JSON.parse(process.env.PROTECTED_PATHS || "[]");
 } catch (err) {
-  console.warn("Ignoring invalid PROTECTED_PATHS env var", err);
-  PROTECTED_PATHS = [];
+  console.error("Invalid PROTECTED_PATHS env var", err);
+  process.exit(1);
 }
 
 const IGNORE_DIRS = new Set([

--- a/dist/automation/review-repo.js
+++ b/dist/automation/review-repo.js
@@ -13,8 +13,8 @@ try {
     PROTECTED_PATHS = JSON.parse(process.env.PROTECTED_PATHS || "[]");
 }
 catch (err) {
-    console.warn("Ignoring invalid PROTECTED_PATHS env var", err);
-    PROTECTED_PATHS = [];
+    console.error("Invalid PROTECTED_PATHS env var", err);
+    process.exit(1);
 }
 const IGNORE_DIRS = new Set([
     "node_modules",


### PR DESCRIPTION
## Summary
- exit when `PROTECTED_PATHS` env var is invalid JSON

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b68a9066e4832aa00fe4af686551dd