### PR TITLE
refine prompts to use ideas terminology

### DIFF
--- a/automation/prompt.ts
+++ b/automation/prompt.ts
@@ -22,7 +22,7 @@ async function resolveModel(client: OpenAI): Promise<string> {
 
 export async function planRepo(input: {
   manifest: any;
-  roadmap: { tasks: string; fresh: string };
+  roadmap: { tasks: string; ideas: string };
   vision: { path: string; content: string };
   maxTasks: number;
   protected: string[];

--- a/automation/review-repo.ts
+++ b/automation/review-repo.ts
@@ -170,7 +170,7 @@ async function main() {
   const READ_LIMIT = 8000;
   const readOr = async (p: string) => { try { return trim(await fs.readFile(p, "utf8"), READ_LIMIT); } catch { return ""; } };
   const roadmapDir = path.join(TARGET_PATH, "roadmap");
-  const roadmapFresh = await readOr(path.join(roadmapDir, "new.md"));
+  const roadmapIdeas = await readOr(path.join(roadmapDir, "new.md"));
   const roadmapTasks = await readOr(path.join(roadmapDir, "tasks.md"));
   const vision = await (async () => {
     for (const rel of ["vision.md", "roadmap/vision.md"]) {
@@ -180,7 +180,7 @@ async function main() {
   })();
 
   const sizeOf = (obj: any) => JSON.stringify(obj).length
-    + roadmapFresh.length + roadmapTasks.length + vision.content.length;
+    + roadmapIdeas.length + roadmapTasks.length + vision.content.length;
   while (sizeOf(manifest) > MAX_INPUT_CHARS) {
     const idx = manifest.files.findLastIndex((f: any) => !!f.sample);
     if (idx === -1) break;
@@ -191,7 +191,7 @@ async function main() {
 
   const plan = await planRepo({
     manifest,
-    roadmap: { tasks: roadmapTasks, fresh: roadmapFresh },
+    roadmap: { tasks: roadmapTasks, ideas: roadmapIdeas },
     vision,
     maxTasks: MAX_TASKS,
     protected: PROTECTED_PATHS,

--- a/dist/automation/review-repo.js
+++ b/dist/automation/review-repo.js
@@ -165,7 +165,7 @@ async function main() {
         return "";
     } };
     const roadmapDir = path.join(TARGET_PATH, "roadmap");
-    const roadmapFresh = await readOr(path.join(roadmapDir, "new.md"));
+    const roadmapIdeas = await readOr(path.join(roadmapDir, "new.md"));
     const roadmapTasks = await readOr(path.join(roadmapDir, "tasks.md"));
     const vision = await (async () => {
         for (const rel of ["vision.md", "roadmap/vision.md"]) {
@@ -177,7 +177,7 @@ async function main() {
         return { path: "", content: "" };
     })();
     const sizeOf = (obj) => JSON.stringify(obj).length
-        + roadmapFresh.length + roadmapTasks.length + vision.content.length;
+        + roadmapIdeas.length + roadmapTasks.length + vision.content.length;
     while (sizeOf(manifest) > MAX_INPUT_CHARS) {
         const idx = manifest.files.findLastIndex((f) => !!f.sample);
         if (idx === -1)
@@ -187,7 +187,7 @@ async function main() {
     console.log(`[review] vision doc: ${vision.path || "none"}`);
     const plan = await planRepo({
         manifest,
-        roadmap: { tasks: roadmapTasks, fresh: roadmapFresh },
+        roadmap: { tasks: roadmapTasks, ideas: roadmapIdeas },
         vision,
         maxTasks: MAX_TASKS,
         protected: PROTECTED_PATHS,

--- a/dist/cmds/review-repo.js
+++ b/dist/cmds/review-repo.js
@@ -28,7 +28,7 @@ export async function reviewRepo() {
         const tasks = await fetchRoadmap("tasks");
         const bugs = await fetchRoadmap("bugs");
         const done = await fetchRoadmap("done");
-        const fresh = await fetchRoadmap("new");
+        const ideas = await fetchRoadmap("new");
         const state = await loadState();
         const { owner, repo } = parseRepo(ENV.TARGET_REPO);
         const commitsResp = await gh().rest.repos.listCommits({ owner, repo, per_page: 10 });
@@ -44,11 +44,11 @@ export async function reviewRepo() {
         }
         const recent = commitsData.map((c) => `${c.sha.slice(0, 7)} ${c.commit.message.split("\n")[0]}`);
         // 1. Generate high-level summary
-        const summaryInput = { commits: recent, vision, tasks, bugs, done, fresh };
+        const summaryInput = { commits: recent, vision, tasks, bugs, done, ideas };
         const summary = await reviewToSummary(summaryInput);
         await upsertFile("reports/repo_summary.md", () => summary, "bot: update repo summary");
         // 2. Generate actionable ideas from summary
-        const ideasInput = { summary, vision, tasks, bugs, done, fresh };
+        const ideasInput = { summary, vision, tasks, bugs, done, ideas };
         const ideasYaml = await reviewToIdeas(ideasInput);
         // 3. Insert new ideas into Supabase
         const newIdeas = yaml.load(ideasYaml)?.queue || [];

--- a/dist/lib/prompts.js
+++ b/dist/lib/prompts.js
@@ -65,7 +65,7 @@ export async function reviewToIdeas(input) {
     return r.choices[0]?.message?.content ?? "";
 }
 /**
- * Promote items from roadmap/new.md (ideas queue) → tasks with unique priorities (1..N).
+ * Promote Supabase ideas into tasks with unique priorities (1..N).
  * Return YAML (items: [...]) in a code block; caller merges & enforces limits.
  */
 export async function synthesizeTasksPrompt(input) {
@@ -73,7 +73,7 @@ export async function synthesizeTasksPrompt(input) {
     const messages = [
         {
             role: "system",
-            content: "Promote items from roadmap/new.md (ideas queue) into tasks.\n" +
+            content: "Promote Supabase ideas into tasks.\n" +
                 "Return ONLY YAML in a code block with the shape:\n```yaml\nitems:\n  - id: <leave blank or omit>\n    type: bug|improvement|feature\n    title: <short>\n    desc: <2–4 lines>\n    source: logs|review|user|vision\n    created: <ISO>\n    priority: <int>\n```\n" +
                 "Rules: no duplicates vs existing tasks; unique priorities 1..N; prefer critical bugs and user-impactful work; cap at ~100."
         },
@@ -101,7 +101,7 @@ export async function implementPlan(input) {
     const messages = [
         {
             role: "system",
-            content: "You are a senior developer. Develope task and deliver in a safe diff. " +
+            content: "You are a senior developer. Develop the task and deliver a safe diff. " +
                 "Output ONLY JSON with keys: operations (array of {path, action:create|update, content?}), testHint, commitTitle, commitBody. " +
                 "Keep diffs tangible; only files relevant to the task; include at least one test file if a test harness exists; avoid broad refactors."
         },

--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -25,7 +25,7 @@ export async function reviewRepo() {
     const tasks  = await fetchRoadmap("tasks");
     const bugs   = await fetchRoadmap("bugs");
     const done   = await fetchRoadmap("done");
-    const fresh  = await fetchRoadmap("new");
+    const ideas  = await fetchRoadmap("new");
 
     const state = await loadState();
     const { owner, repo } = parseRepo(ENV.TARGET_REPO);
@@ -42,12 +42,12 @@ export async function reviewRepo() {
     );
 
     // 1. Generate high-level summary
-    const summaryInput = { commits: recent, vision, tasks, bugs, done, fresh };
+    const summaryInput = { commits: recent, vision, tasks, bugs, done, ideas };
     const summary = await reviewToSummary(summaryInput);
     await upsertFile("reports/repo_summary.md", () => summary, "bot: update repo summary");
 
     // 2. Generate actionable ideas from summary
-    const ideasInput = { summary, vision, tasks, bugs, done, fresh };
+    const ideasInput = { summary, vision, tasks, bugs, done, ideas };
     const ideasYaml = await reviewToIdeas(ideasInput);
 
     // 3. Insert new ideas into Supabase

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -46,7 +46,7 @@ export async function reviewToSummary(input: {
   tasks: string;
   bugs: string;
   done: string;
-  fresh: string; // current new.md content
+  ideas: string; // current ideas queue content
 }): Promise<string> {
   const openai = getOpenAI();
   const messages = [
@@ -74,7 +74,7 @@ export async function reviewToIdeas(input: {
   tasks: string;
   bugs: string;
   done: string;
-  fresh: string; // current new.md content
+  ideas: string; // current ideas queue content
 }): Promise<string> {
   const openai = getOpenAI();
   const messages = [
@@ -95,7 +95,7 @@ export async function reviewToIdeas(input: {
 }
 
 /**
- * Promote items from roadmap/new.md (ideas queue) → tasks with unique priorities (1..N).
+ * Promote Supabase ideas into tasks with unique priorities (1..N).
  * Return YAML (items: [...]) in a code block; caller merges & enforces limits.
  */
 export async function synthesizeTasksPrompt(input: {
@@ -110,7 +110,7 @@ export async function synthesizeTasksPrompt(input: {
     {
       role: "system" as const,
       content:
-        "Promote items from roadmap/new.md (ideas queue) into tasks.\n" +
+        "Promote Supabase ideas into tasks.\n" +
         "Return ONLY YAML in a code block with the shape:\n```yaml\nitems:\n  - id: <leave blank or omit>\n    type: bug|improvement|feature\n    title: <short>\n    desc: <2–4 lines>\n    source: logs|review|user|vision\n    created: <ISO>\n    priority: <int>\n```\n" +
         "Rules: no duplicates vs existing tasks; unique priorities 1..N; prefer critical bugs and user-impactful work; cap at ~100."
     },


### PR DESCRIPTION
## Summary
- rename `fresh` argument to `ideas` in summary/ideas prompts and update system message for Supabase tasks
- update review and planning scripts to pass new `ideas` field

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b69001d608832a98d58a8845339f8d