### PR TITLE
Store repo summary in Supabase

### DIFF
--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -1,5 +1,5 @@
 import { acquireLock, releaseLock } from "../lib/lock.js";
-import { parseRepo, gh, upsertFile } from "../lib/github.js";
+import { parseRepo, gh } from "../lib/github.js";
 import { reviewToIdeas, reviewToSummary } from "../lib/prompts.js";
 import { loadState, saveState, appendChangelog, appendDecision } from "../lib/state.js";
 import { requireEnv, ENV } from "../lib/env.js";
@@ -44,7 +44,22 @@ export async function reviewRepo() {
     // 1. Generate high-level summary
     const summaryInput = { commits: recent, vision, tasks, bugs, done, fresh };
     const summary = await reviewToSummary(summaryInput);
-    await upsertFile("reports/repo_summary.md", () => summary, "bot: update repo summary");
+    await fetch(`${process.env.SUPABASE_URL}/rest/v1/roadmap_items`, {
+      method: "POST",
+      headers: {
+        apikey: process.env.SUPABASE_SERVICE_ROLE_KEY!,
+        Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY!}`,
+        "Content-Type": "application/json",
+        Prefer: "return=minimal",
+      },
+      body: JSON.stringify({
+        id: `SUMMARY-${Date.now()}`,
+        type: "summary",
+        content: summary,
+        created: new Date().toISOString(),
+      }),
+    });
+    console.log("Stored repo summary in Supabase.");
 
     // 2. Generate actionable ideas from summary
     const ideasInput = { summary, vision, tasks, bugs, done, fresh };
@@ -73,7 +88,7 @@ export async function reviewRepo() {
 
     const headSha = commitsData[0]?.sha;
     await saveState({ ...state, lastReviewedSha: headSha });
-    await appendChangelog("Reviewed repository and recorded summary.");
+    await appendChangelog("Reviewed repository and stored summary in Supabase.");
     await appendDecision(`Updated lastReviewedSha to ${headSha}.`);
     console.log("Review complete.");
   } finally {


### PR DESCRIPTION
## Summary
- Insert repository summary into Supabase instead of upserting a markdown file
- Update review command logs and changelog message to reflect Supabase storage

## Testing
- `npm run build`
- `npm run check`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b690022df8832ab6ac67b0198d0d3e