### PR TITLE
fix: trim Supabase roadmap payloads

### DIFF
--- a/automation/review-repo.ts
+++ b/automation/review-repo.ts
@@ -187,7 +187,8 @@ async function main() {
     });
     if (!resp.ok) return "";
     const data = await resp.json();
-    return data.map((r: { content: string }) => r.content).join("\n");
+    const content = data.map((r: { content: string }) => r.content).join("\n");
+    return trim(content, READ_LIMIT);
   }
   const roadmapFresh = await fetchRoadmap("new");
   const roadmapTasks = await fetchRoadmap("task");


### PR DESCRIPTION
## Summary
- limit Supabase roadmap content to READ_LIMIT before manifest sizing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b692b6147c832ab5d257695faeeed7