### PR TITLE
docs: reference Supabase for repo summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ Files & conventions the agent uses
 	•	agent/config.json – project hints (framework, package manager, test scripts), and guardrails.
 	•	Supabase tables – run metadata, decisions, and changelog entries.
 	•	Supabase tasks table – backlog the agent pulls from (the agent can propose ~30 items if empty).
-	•	reports/repo_summary.md – ephemeral repo overview (kept out of the tasks table to avoid your deletion rule).
+        •       Repo summaries stored in Supabase – ephemeral overviews kept out of the tasks table to avoid your deletion rule.
 	•	.github/workflows/ai-dev-agent.yml – schedule (e.g., every 4h) and permissions.
 
-Note: backlog items are stored in Supabase; the agent writes repo scans to reports/repo_summary.md to keep tasks separate.
+Note: backlog items and repo summaries are stored in Supabase to keep tasks separate.
 
 Triggers & cadence
 	•	Cron (e.g., hourly/4-hourly) and on push to default branch.


### PR DESCRIPTION
## Summary
- clarify that repo summaries are stored in Supabase instead of a local reports file

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b6c504215c832aa457e1e1531ed534