### PR TITLE
ci: enable roadmap normalization workflow

### DIFF
--- a/.github/workflows/agent-normalize-roadmap.yml
+++ b/.github/workflows/agent-normalize-roadmap.yml
@@ -1,19 +1,43 @@
-#name: agent-normalize-roadmap
+name: agent-normalize-roadmap
 on:
- # schedule: [{ cron: "22 3 * * *" }]
- # workflow_dispatch:
-#jobs:
-  normalize:
+  schedule:
+    - cron: "22 3 * * *"    # 03:22 UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ai-dev-agent-global
+  cancel-in-progress: false
+
+jobs:
+  normalize-roadmap:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
+      - name: Ensure lockfile (first run)
+        run: |
+          if [ ! -f package-lock.json ]; then
+            npm install --package-lock-only --no-audit --no-fund
+          fi
       - run: npm ci --no-audit --no-fund
       - run: npm run build
       - run: node dist/cli.js normalize-roadmap
         env:
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
           TARGET_REPO: ${{ secrets.TARGET_REPO }}
+          TARGET_DIR: ${{ secrets.TARGET_DIR }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          AI_BOT_WRITE_MODE: commit
+          DRY_RUN: "0"
+          ALLOW_PATHS: ""


### PR DESCRIPTION
## Summary
- enable agent-normalize-roadmap workflow with daily schedule
- include standard environment variables for normalization job

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68b6d149e154832a9882fb2d5d8b1bd9