### PR TITLE
chore: restrict workflow permissions

### DIFF
--- a/.github/workflows/agent-ingest-logs.yml
+++ b/.github/workflows/agent-ingest-logs.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ai-dev-agent-global
@@ -39,6 +39,5 @@ jobs:
           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          AI_BOT_WRITE_MODE: commit
-          DRY_RUN: "0"
+          DRY_RUN: "1"
           ALLOW_PATHS: ""

--- a/.github/workflows/agent-review-repo.yml
+++ b/.github/workflows/agent-review-repo.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ai-dev-agent-global
@@ -39,6 +39,5 @@ jobs:
           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          AI_BOT_WRITE_MODE: commit
-          DRY_RUN: "0"
+          DRY_RUN: "1"
           ALLOW_PATHS: ""

--- a/.github/workflows/agent-synthesize-tasks.yml
+++ b/.github/workflows/agent-synthesize-tasks.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ai-dev-agent-global
@@ -38,6 +38,5 @@ jobs:
           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          AI_BOT_WRITE_MODE: commit
-          DRY_RUN: "0"
+          DRY_RUN: "1"
           ALLOW_PATHS: ""


### PR DESCRIPTION
## Summary
- limit agent-ingest-logs, agent-review-repo, and agent-synthesize-tasks workflows to read-only
- run these workflows in dry-run mode to avoid accidental commits

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b6d738b9b0832abe63a3d66f802d42