### PR TITLE
chore: remove unused vercel secrets from workflow

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -34,9 +34,6 @@ jobs:
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
           TARGET_REPO: ${{ secrets.TARGET_REPO }}
           TARGET_DIR: ${{ secrets.TARGET_DIR }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}


### PR DESCRIPTION
## Summary
- remove Vercel-related secrets from `agent-implement` workflow env block

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b6db1f6040832abc2e2982d8a78d3c