### PR TITLE
refactor: centralize supabase interactions

### DIFF
--- a/dist/cmds/review-repo.js
+++ b/dist/cmds/review-repo.js
@@ -3,6 +3,7 @@ import { parseRepo, gh } from "../lib/github.js";
 import { reviewToIdeas, reviewToSummary } from "../lib/prompts.js";
 import { loadState, saveState, appendChangelog, appendDecision } from "../lib/state.js";
 import { requireEnv, ENV } from "../lib/env.js";
+import { sbRequest } from "../lib/supabase.js";
 import yaml from "js-yaml";
 export async function reviewRepo() {
     if (!(await acquireLock())) {
@@ -12,17 +13,8 @@ export async function reviewRepo() {
     try {
         requireEnv(["TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
         async function fetchRoadmap(type) {
-            const url = `${process.env.SUPABASE_URL}/rest/v1/roadmap_items?select=content&type=eq.${type}`;
-            const resp = await fetch(url, {
-                headers: {
-                    apikey: process.env.SUPABASE_SERVICE_ROLE_KEY,
-                    Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
-                },
-            });
-            if (!resp.ok)
-                return "";
-            const data = await resp.json();
-            return data.map((r) => r.content).join("\n");
+            const data = (await sbRequest(`roadmap_items?select=content&type=eq.${type}`));
+            return data ? data.map((r) => r.content).join("\n") : "";
         }
         const vision = await fetchRoadmap("vision");
         const tasks = await fetchRoadmap("tasks");
@@ -46,14 +38,9 @@ export async function reviewRepo() {
         // 1. Generate high-level summary
         const summaryInput = { commits: recent, vision, tasks, bugs, done, ideas };
         const summary = await reviewToSummary(summaryInput);
-        await fetch(`${process.env.SUPABASE_URL}/rest/v1/roadmap_items`, {
+        await sbRequest("roadmap_items", {
             method: "POST",
-            headers: {
-                apikey: process.env.SUPABASE_SERVICE_ROLE_KEY,
-                Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
-                "Content-Type": "application/json",
-                Prefer: "return=minimal",
-            },
+            headers: { "Content-Type": "application/json", Prefer: "return=minimal" },
             body: JSON.stringify({
                 id: `SUMMARY-${Date.now()}`,
                 type: "summary",
@@ -74,14 +61,9 @@ export async function reviewRepo() {
                 content: yaml.dump(idea),
                 created: idea.created || new Date().toISOString(),
             };
-            await fetch(`${process.env.SUPABASE_URL}/rest/v1/roadmap_items`, {
+            await sbRequest("roadmap_items", {
                 method: "POST",
-                headers: {
-                    apikey: process.env.SUPABASE_SERVICE_ROLE_KEY,
-                    Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
-                    "Content-Type": "application/json",
-                    Prefer: "return=minimal",
-                },
+                headers: { "Content-Type": "application/json", Prefer: "return=minimal" },
                 body: JSON.stringify(payload),
             });
         }

--- a/dist/lib/state.js
+++ b/dist/lib/state.js
@@ -1,28 +1,4 @@
-import { ENV } from "./env.js";
-const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = ENV;
-function requireSupabase() {
-    if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
-        throw new Error("Missing Supabase credentials: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY is undefined");
-    }
-}
-async function sbRequest(path, init = {}) {
-    requireSupabase();
-    const url = `${SUPABASE_URL}/rest/v1/${path}`;
-    const headers = {
-        apikey: SUPABASE_SERVICE_ROLE_KEY,
-        Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
-        "Content-Type": "application/json",
-        ...init.headers,
-    };
-    const res = await fetch(url, { ...init, headers });
-    if (!res.ok) {
-        throw new Error(`Supabase error: ${res.status} ${res.statusText}`);
-    }
-    if (res.status === 204 || res.headers.get("Content-Length") === "0") {
-        return undefined;
-    }
-    return res.json();
-}
+import { sbRequest } from "./supabase.js";
 export async function loadState() {
     const data = (await sbRequest("agent_state?select=data&limit=1"));
     const row = data?.[0];

--- a/dist/lib/supabase.js
+++ b/dist/lib/supabase.js
@@ -1,4 +1,38 @@
 import { createClient } from "@supabase/supabase-js";
-import { ENV, requireEnv } from "./env.js";
-requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
-export const supabase = createClient(ENV.SUPABASE_URL, ENV.SUPABASE_SERVICE_ROLE_KEY);
+import { ENV } from "./env.js";
+function requireSupabase() {
+    if (!ENV.SUPABASE_URL || !ENV.SUPABASE_SERVICE_ROLE_KEY) {
+        throw new Error("Missing Supabase credentials: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY is undefined");
+    }
+}
+let client;
+function getClient() {
+    requireSupabase();
+    if (!client) {
+        client = createClient(ENV.SUPABASE_URL, ENV.SUPABASE_SERVICE_ROLE_KEY);
+    }
+    return client;
+}
+export const supabase = new Proxy({}, {
+    get(_target, prop, receiver) {
+        return Reflect.get(getClient(), prop, receiver);
+    },
+});
+export async function sbRequest(path, init = {}) {
+    requireSupabase();
+    const url = `${ENV.SUPABASE_URL}/rest/v1/${path}`;
+    const headers = {
+        apikey: ENV.SUPABASE_SERVICE_ROLE_KEY,
+        Authorization: `Bearer ${ENV.SUPABASE_SERVICE_ROLE_KEY}`,
+        "Content-Type": "application/json",
+        ...init.headers,
+    };
+    const res = await fetch(url, { ...init, headers });
+    if (!res.ok) {
+        throw new Error(`Supabase error: ${res.status} ${res.statusText}`);
+    }
+    if (res.status === 204 || res.headers.get("Content-Length") === "0") {
+        return undefined;
+    }
+    return res.json();
+}

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,33 +1,4 @@
-import { ENV } from "./env.js";
-
-const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = ENV;
-
-function requireSupabase() {
-  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
-    throw new Error(
-      "Missing Supabase credentials: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY is undefined"
-    );
-  }
-}
-
-async function sbRequest(path: string, init: RequestInit = {}) {
-  requireSupabase();
-  const url = `${SUPABASE_URL}/rest/v1/${path}`;
-  const headers: Record<string, string> = {
-    apikey: SUPABASE_SERVICE_ROLE_KEY!,
-    Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
-    "Content-Type": "application/json",
-    ...(init.headers as Record<string, string>),
-  };
-  const res = await fetch(url, { ...init, headers });
-  if (!res.ok) {
-    throw new Error(`Supabase error: ${res.status} ${res.statusText}`);
-  }
-  if (res.status === 204 || res.headers.get("Content-Length") === "0") {
-    return undefined;
-  }
-  return res.json();
-}
+import { sbRequest } from "./supabase.js";
 
 export type AgentState = {
   ingest?: { lastDeploymentTimestamp?: number; lastRowIds?: string[] };

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,9 +1,46 @@
 
-import { createClient } from "@supabase/supabase-js";
-import { ENV, requireEnv } from "./env.js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { ENV } from "./env.js";
 
-requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
-export const supabase = createClient(
-  ENV.SUPABASE_URL,
-  ENV.SUPABASE_SERVICE_ROLE_KEY
-);
+function requireSupabase() {
+  if (!ENV.SUPABASE_URL || !ENV.SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error(
+      "Missing Supabase credentials: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY is undefined"
+    );
+  }
+}
+
+let client: SupabaseClient | undefined;
+
+function getClient(): SupabaseClient {
+  requireSupabase();
+  if (!client) {
+    client = createClient(ENV.SUPABASE_URL, ENV.SUPABASE_SERVICE_ROLE_KEY);
+  }
+  return client;
+}
+
+export const supabase = new Proxy({} as SupabaseClient, {
+  get(_target, prop, receiver) {
+    return Reflect.get(getClient() as any, prop, receiver);
+  },
+});
+
+export async function sbRequest(path: string, init: RequestInit = {}) {
+  requireSupabase();
+  const url = `${ENV.SUPABASE_URL}/rest/v1/${path}`;
+  const headers: Record<string, string> = {
+    apikey: ENV.SUPABASE_SERVICE_ROLE_KEY!,
+    Authorization: `Bearer ${ENV.SUPABASE_SERVICE_ROLE_KEY}`,
+    "Content-Type": "application/json",
+    ...(init.headers as Record<string, string>),
+  };
+  const res = await fetch(url, { ...init, headers });
+  if (!res.ok) {
+    throw new Error(`Supabase error: ${res.status} ${res.statusText}`);
+  }
+  if (res.status === 204 || res.headers.get("Content-Length") === "0") {
+    return undefined;
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- centralize supabase client logic in lib/supabase with sbRequest helper
- refactor state management to use shared sbRequest
- replace manual fetches in review-repo with sbRequest and ENV values

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b6f6928f60832aa5f3cfb092fa484e