### PR TITLE
Fetch roadmap types concurrently

### DIFF
--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -16,11 +16,10 @@ export async function reviewRepo() {
       )) as { content: string }[] | undefined;
       return data ? data.map((r) => r.content).join("\n") : "";
     }
-    const vision = await fetchRoadmap("vision");
-    const tasks  = await fetchRoadmap("tasks");
-    const bugs   = await fetchRoadmap("bugs");
-    const done   = await fetchRoadmap("done");
-    const ideas  = await fetchRoadmap("new");
+    const roadmapTypes = ["vision", "tasks", "bugs", "done", "new"];
+    const [vision, tasks, bugs, done, ideas] = await Promise.all(
+      roadmapTypes.map(fetchRoadmap),
+    );
 
     const state = await loadState();
     const { owner, repo } = parseRepo(ENV.TARGET_REPO);


### PR DESCRIPTION
## Summary
- Batch roadmap item types into an array and retrieve them in parallel with Promise.all
- Destructure the resolved roadmap content into vision, tasks, bugs, done, and ideas variables

## Testing
- `npx --yes vitest@3.2.4 run`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b6f94bc51c832a959d26aaa64341f0