### PR TITLE
refactor: reuse single Octokit client

### DIFF
--- a/dist/cmds/review-repo.js
+++ b/dist/cmds/review-repo.js
@@ -16,14 +16,11 @@ export async function reviewRepo() {
             const data = (await sbRequest(`roadmap_items?select=content&type=eq.${type}`));
             return data ? data.map((r) => r.content).join("\n") : "";
         }
-        const vision = await fetchRoadmap("vision");
-        const tasks = await fetchRoadmap("tasks");
-        const bugs = await fetchRoadmap("bugs");
-        const done = await fetchRoadmap("done");
-        const ideas = await fetchRoadmap("new");
+        const roadmapTypes = ["vision", "tasks", "bugs", "done", "new"];
+        const [vision, tasks, bugs, done, ideas] = await Promise.all(roadmapTypes.map(fetchRoadmap));
         const state = await loadState();
         const { owner, repo } = parseRepo(ENV.TARGET_REPO);
-        const commitsResp = await gh().rest.repos.listCommits({ owner, repo, per_page: 10 });
+        const commitsResp = await gh.rest.repos.listCommits({ owner, repo, per_page: 10 });
         const commitsData = [];
         for (const c of commitsResp.data) {
             if (c.sha === state.lastReviewedSha)

--- a/dist/lib/github.js
+++ b/dist/lib/github.js
@@ -1,6 +1,7 @@
 import { Octokit } from "octokit";
 import { posix as pathPosix } from "node:path";
 import { ENV } from "./env.js";
+export const gh = new Octokit({ auth: ENV.PAT_TOKEN });
 function formatMessage(msg) {
     if (typeof msg === "string")
         return msg;
@@ -12,16 +13,12 @@ export function parseRepo(s) {
         throw new Error(`Invalid TARGET_REPO: ${s}`);
     return { owner, repo };
 }
-export function gh() {
-    return new Octokit({ auth: ENV.PAT_TOKEN });
-}
 function b64(s) {
     return Buffer.from(s, "utf8").toString("base64");
 }
 async function getFile(owner, repo, path, ref) {
-    const client = gh();
     try {
-        const res = await client.rest.repos.getContent({ owner, repo, path, ref });
+        const res = await gh.rest.repos.getContent({ owner, repo, path, ref });
         const data = res.data;
         if (Array.isArray(data))
             throw new Error(`Expected file at ${path}, got directory`);
@@ -37,14 +34,14 @@ async function getFile(owner, repo, path, ref) {
 }
 export async function getDefaultBranch() {
     const { owner, repo } = parseRepo(ENV.TARGET_REPO);
-    const { data } = await gh().rest.repos.get({ owner, repo });
+    const { data } = await gh.rest.repos.get({ owner, repo });
     return data.default_branch;
 }
 export async function ensureBranch(branch, baseBranch) {
     const { owner, repo } = parseRepo(ENV.TARGET_REPO);
     const ref = `heads/${branch}`;
     try {
-        await gh().rest.git.getRef({ owner, repo, ref });
+        await gh.rest.git.getRef({ owner, repo, ref });
         return;
     }
     catch (e) {
@@ -52,9 +49,9 @@ export async function ensureBranch(branch, baseBranch) {
             throw e;
     }
     const base = baseBranch || await getDefaultBranch();
-    const baseRef = await gh().rest.git.getRef({ owner, repo, ref: `heads/${base}` });
+    const baseRef = await gh.rest.git.getRef({ owner, repo, ref: `heads/${base}` });
     const baseSha = baseRef.data.object.sha;
-    await gh().rest.git.createRef({ owner, repo, ref: `refs/heads/${branch}`, sha: baseSha });
+    await gh.rest.git.createRef({ owner, repo, ref: `refs/heads/${branch}`, sha: baseSha });
 }
 export function resolveRepoPath(p) {
     if (!p)
@@ -89,7 +86,7 @@ export async function upsertFile(path, updater, message, opts) {
     }
     const { sha, content: old } = await getFile(owner, repo, safePath, ref);
     const next = updater(old);
-    await gh().rest.repos.createOrUpdateFileContents({
+    await gh.rest.repos.createOrUpdateFileContents({
         owner,
         repo,
         path: safePath,
@@ -114,7 +111,7 @@ export async function commitMany(files, message, opts) {
         return;
     }
     const branch = ref || (await getDefaultBranch());
-    const git = gh().rest.git;
+    const git = gh.rest.git;
     const headRef = await git.getRef({ owner, repo, ref: `heads/${branch}` });
     const latestCommitSha = headRef.data.object.sha;
     const latestCommit = await git.getCommit({

--- a/dist/orchestrator.js
+++ b/dist/orchestrator.js
@@ -21,7 +21,7 @@ async function shouldReview(state) {
         if (!ENV.TARGET_REPO)
             return false;
         const { owner, repo } = parseRepo(ENV.TARGET_REPO);
-        const resp = await gh().rest.repos.listCommits({ owner, repo, per_page: 1 });
+        const resp = await gh.rest.repos.listCommits({ owner, repo, per_page: 1 });
         const latest = resp.data[0]?.sha;
         return !!latest && latest !== state.lastReviewedSha;
     }

--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -23,7 +23,7 @@ export async function reviewRepo() {
 
     const state = await loadState();
     const { owner, repo } = parseRepo(ENV.TARGET_REPO);
-    const commitsResp = await gh().rest.repos.listCommits({ owner, repo, per_page: 10 });
+    const commitsResp = await gh.rest.repos.listCommits({ owner, repo, per_page: 10 });
     const commitsData = [] as { sha: string; commit: { message: string } }[];
     for (const c of commitsResp.data) {
       if (c.sha === state.lastReviewedSha) break;

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -20,7 +20,7 @@ async function shouldReview(state: AgentState): Promise<boolean> {
   try {
     if (!ENV.TARGET_REPO) return false;
     const { owner, repo } = parseRepo(ENV.TARGET_REPO);
-    const resp = await gh().rest.repos.listCommits({ owner, repo, per_page: 1 });
+    const resp = await gh.rest.repos.listCommits({ owner, repo, per_page: 1 });
     const latest = resp.data[0]?.sha;
     return !!latest && latest !== state.lastReviewedSha;
   } catch {


### PR DESCRIPTION
## Summary
- reuse a single Octokit client instance across the codebase
- update orchestrator and review-repo to use shared GitHub client

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b6fe9b4310832a9fdb0ee12a44fba1