### PR TITLE
Normalize ideas YAML before parsing

### DIFF
--- a/dist/cmds/review-repo.js
+++ b/dist/cmds/review-repo.js
@@ -49,8 +49,14 @@ export async function reviewRepo() {
         // 2. Generate actionable ideas from summary
         const ideasInput = { summary, vision, tasks, bugs, done, ideas };
         const ideasYaml = await reviewToIdeas(ideasInput);
+        // Normalize by removing fenced code block markers if present
+        const normalizedIdeasYaml = ideasYaml
+            .trim()
+            .replace(/^```(?:yaml)?\n?/i, "")
+            .replace(/\n?```$/, "")
+            .trim();
         // 3. Insert new ideas into Supabase
-        const newIdeas = yaml.load(ideasYaml)?.queue || [];
+        const newIdeas = yaml.load(normalizedIdeasYaml)?.queue || [];
         for (const idea of newIdeas) {
             const payload = {
                 id: idea.id || `IDEA-${Date.now()}`,

--- a/dist/lib/prompts.js
+++ b/dist/lib/prompts.js
@@ -53,7 +53,7 @@ export async function reviewToIdeas(input) {
         {
             role: "system",
             content: "You are an experienced software architect. Based on the provided summary and other context, propose concise, actionable items for a code bot. Include tasks that make visible progress for the end user." +
-                "Return ONLY YAML in a code block with the shape:\n```yaml\nqueue:\n  - id: <leave blank or omit>\n    title: <short>\n    details: <1-3 lines>\n    created: <ISO>\n```" +
+                "Return ONLY YAML with the shape:\nqueue:\n  - id: <leave blank or omit>\n    title: <short>\n    details: <1-3 lines>\n    created: <ISO>\n" +
                 "\nAvoid duplicates vs the provided lists. Focus on the opportunities identified in the summary."
         },
         { role: "user", content: JSON.stringify(input, null, 2) }

--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -53,9 +53,16 @@ export async function reviewRepo() {
     // 2. Generate actionable ideas from summary
     const ideasInput = { summary, vision, tasks, bugs, done, ideas };
     const ideasYaml = await reviewToIdeas(ideasInput);
+    // Normalize by removing fenced code block markers if present
+    const normalizedIdeasYaml = ideasYaml
+      .trim()
+      .replace(/^```(?:yaml)?\n?/i, "")
+      .replace(/\n?```$/, "")
+      .trim();
 
     // 3. Insert new ideas into Supabase
-    const newIdeas = (yaml.load(ideasYaml) as { queue: any[] })?.queue || [];
+    const newIdeas =
+      (yaml.load(normalizedIdeasYaml) as { queue: any[] })?.queue || [];
     for (const idea of newIdeas) {
       const payload = {
         id: idea.id || `IDEA-${Date.now()}`,

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -77,16 +77,16 @@ export async function reviewToIdeas(input: {
   ideas: string; // current ideas queue content
 }): Promise<string> {
   const openai = getOpenAI();
-  const messages = [
-    {
-      role: "system" as const,
-      content:
-        "You are an experienced software architect. Based on the provided summary and other context, propose concise, actionable items for a code bot. Include tasks that make visible progress for the end user." +
-        "Return ONLY YAML in a code block with the shape:\n```yaml\nqueue:\n  - id: <leave blank or omit>\n    title: <short>\n    details: <1-3 lines>\n    created: <ISO>\n```" +
-        "\nAvoid duplicates vs the provided lists. Focus on the opportunities identified in the summary."
-    },
-    { role: "user" as const, content: JSON.stringify(input, null, 2) }
-  ];
+    const messages = [
+      {
+        role: "system" as const,
+        content:
+          "You are an experienced software architect. Based on the provided summary and other context, propose concise, actionable items for a code bot. Include tasks that make visible progress for the end user." +
+          "Return ONLY YAML with the shape:\nqueue:\n  - id: <leave blank or omit>\n    title: <short>\n    details: <1-3 lines>\n    created: <ISO>\n" +
+          "\nAvoid duplicates vs the provided lists. Focus on the opportunities identified in the summary."
+      },
+      { role: "user" as const, content: JSON.stringify(input, null, 2) }
+    ];
   const r = await openai.chat.completions.create({
     model: ENV.OPENAI_MODEL,
     messages


### PR DESCRIPTION
## Summary
- Strip leading/trailing YAML code fences before parsing ideas in `review-repo`
- Update `reviewToIdeas` prompt to request plain YAML responses (no code fences)

## Testing
- `npm run build`
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b70a752c64832a86a7b75470ceb3e2