### PR TITLE
fix: include tasks without status

### DIFF
--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -26,7 +26,7 @@ export async function implementTopTask() {
       .from("roadmap_items")
       .select("*")
       .eq("type", "task")
-      .neq("status", "done")
+      .or("status.is.null,status.neq.done")
       .order("priority", { ascending: true })
       .limit(1);
     if (error) { console.error("Failed to fetch tasks", error); return; }


### PR DESCRIPTION
## Summary
- include tasks with null status when querying roadmap_items

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b749ca21ac832aba2c0a852514222f