### PR TITLE
feat: log roadmap task completion

### DIFF
--- a/dist/lib/tasks.js
+++ b/dist/lib/tasks.js
@@ -4,13 +4,14 @@ import { supabase } from "./supabase.js";
  * Uses a stored procedure or upsert to ensure both actions occur atomically.
  */
 export async function completeTask(task) {
-    const { error } = await supabase.rpc("complete_roadmap_task", {
+    const params = {
         item_id: task.id,
         title: task.title,
         details: task.desc,
-        type: task.type,
         priority: task.priority,
-    });
+        ...(task.type != null ? { type: task.type } : {}),
+    };
+    const { error } = await supabase.rpc("complete_roadmap_task", params);
     if (error)
         throw error;
 }

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -6,13 +6,15 @@ import type { Task } from "./types.js";
  * Uses a stored procedure or upsert to ensure both actions occur atomically.
  */
 export async function completeTask(task: Task) {
-  const { error } = await supabase.rpc("complete_roadmap_task", {
+  const params = {
     item_id: task.id,
     title: task.title,
     details: task.desc,
-    type: task.type,
     priority: task.priority,
-  });
+    ...(task.type != null ? { type: task.type } : {}),
+  };
+
+  const { error } = await supabase.rpc("complete_roadmap_task", params);
   if (error) throw error;
 }
 


### PR DESCRIPTION
## Summary
- log roadmap task completion through new RPC
- use roadmap RPC when marking a task complete
- avoid passing null task type to RPC

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b74d661748832a976e31a2fb8db8b8