### PR TITLE
docs: rename tasks table references

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Inputs & Outputs
 Inputs
 	•	Build signals: Deploy status + logs (e.g., Vercel API), parsed into issues[] and trimmedLogs.
 	•	Repo snapshot: repoFiles[], repoTree[], export facts, package manifests.
-	•	Roadmap: roadmap/vision.md (protected) with tasks tracked in Supabase.
+	•	Roadmap: roadmap/vision.md (protected) with backlog items tracked in the Supabase `roadmap_items` table.
 	•	Constraints: allowedOps[], commitStyle, protected paths, diff size limits.
 	•	Context: Framework/language hints, package manager, test commands.
 
@@ -29,7 +29,7 @@ Outputs
 	•	Agent notes stored in Supabase.
 	•	Roadmap progress: statuses/links back to PRs.
 
-Task progress, decisions, and changelog entries are stored exclusively in Supabase tables.
+Roadmap item progress, decisions, and changelog entries are stored exclusively in Supabase tables.
 
 Two paths in detail
 
@@ -41,7 +41,7 @@ A) Red path — Repair first
 	•	If repair fails after N attempts: open an Issue with a concise reproduction + proposed fix plan; back off.
 
 B) Green path — Continuous improvement
-	•	Prioritize from Supabase tasks (or synthesize from repo gaps if empty).
+	•	Prioritize from Supabase `roadmap_items` (canonical backlog) or synthesize from repo gaps if empty.
 	•	Pick a thin vertical slice (tests + code + docs).
 	•	Implement in small, deployable steps; keep the app green after each step.
 	•	Update backlog item status, link to commit/PR, and record brief rationale in Supabase.
@@ -66,17 +66,17 @@ Guardrails & safety
 	•	Small, reversible steps: diff size limits; rollbacks on post-merge failure.
 	•	Style conformity: enforces formatter/linter/tsc/tests before committing.
         •       Automated validation: `npm run check` and `npm test` run before a commit and the commit is aborted on failure.
-	•	Traceability: every commit links to the problem (log line/issue id) or corresponding Supabase task.
+	•	Traceability: every commit links to the problem (log line/issue id) or corresponding Supabase roadmap item.
 	•	Fallbacks: if blocked by permissions/credentials (e.g., 400/403 from deploy API), it files an actionable Issue rather than guessing.
 
 Files & conventions the agent uses
 	•	agent/config.json – project hints (framework, package manager, test scripts), and guardrails.
 	•	Supabase tables – run metadata, decisions, and changelog entries.
-	•	Supabase tasks table – backlog the agent pulls from (the agent can propose ~30 items if empty).
-        •       Repo summaries stored in Supabase – ephemeral overviews kept out of the tasks table to avoid your deletion rule.
+	•	Supabase `roadmap_items` table – canonical backlog the agent pulls from (the agent can propose ~30 items if empty).
+        •       Repo summaries stored in Supabase – ephemeral overviews kept out of the `roadmap_items` table to avoid your deletion rule.
 	•	.github/workflows/ai-dev-agent.yml – schedule (e.g., every 4h) and permissions.
 
-Note: backlog items and repo summaries are stored in Supabase to keep tasks separate.
+Note: backlog items and repo summaries are stored in Supabase. Older references to a `tasks` table have been replaced by `roadmap_items`.
 
 Triggers & cadence
 	•	Cron (e.g., hourly/4-hourly) and on push to default branch.
@@ -84,7 +84,7 @@ Triggers & cadence
 
 Commit & PR etiquette
 	•	Conventional commits (e.g., fix(api): handle 413 from upload endpoint)
-	•	Body must include: root cause, scope, validation steps, and links to logs/issue/Supabase task.
+	•	Body must include: root cause, scope, validation steps, and links to logs/issue/Supabase roadmap item.
 	•	PR template auto-filled with test evidence and risk notes.
 
 Observability
@@ -100,7 +100,7 @@ Failure & recovery strategy
 Project-agnostic behavior
 	•	Auto-detects language/framework (Next.js, Node, TS/JS, Python, etc.) and chooses idiomatic patterns.
 	•	If no tests exist, proposes and adds the first test around the touched module to start a testing baseline.
-	•	If no tasks exist, seeds the Supabase tasks table with ~30 value-centric items (performance, DX, tests, docs, UX polish) tagged by effort/impact.
+	•	If no roadmap items exist, seeds the Supabase `roadmap_items` table with ~30 value-centric items (performance, DX, tests, docs, UX polish) tagged by effort/impact.
 
 Setup requirements (minimal)
 	•	Credentials: GitHub token (repo), Deploy provider token (e.g., Vercel) + project id.
@@ -113,5 +113,5 @@ Example run (narrative)
 	3.	Parser maps error to bff/utils/fetchData.js and a missing header guard; proposes a 6-line fix + unit test.
 	4.	Runs linter/tsc/tests → green. Commits with linked log snippet.
 	5.	Redeploy kicks → green.
-	6.      Green path: picks “Add API timeout & retry with exponential backoff” from the Supabase tasks backlog.
+	6.      Green path: picks “Add API timeout & retry with exponential backoff” from the Supabase `roadmap_items` backlog.
 	7.	Implements small, feature-flagged change + tests + docs; opens PR with validation steps; logs the rationale in Supabase.

--- a/docs/supabase-schema.md
+++ b/docs/supabase-schema.md
@@ -1,5 +1,7 @@
 # Supabase Schema
 
+The `roadmap_items` table is the canonical backlog and replaces the older `tasks` table.
+
 ## roadmap_items
 
 | Column     | Type                                                | Notes |


### PR DESCRIPTION
## Summary
- use `roadmap_items` as the canonical backlog in docs
- note that the old `tasks` table references were replaced
- clarify Supabase schema to document current tables and RPCs

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b74f073b14832aaa6f8f641e9ed838