### PR TITLE
Normalize roadmap tasks using roadmap_items table

### DIFF
--- a/src/cmds/normalize-roadmap.ts
+++ b/src/cmds/normalize-roadmap.ts
@@ -19,7 +19,10 @@ export async function normalizeRoadmap() {
       .select("*")
       .eq("type", "task");
     if (error) throw error;
-    let items = (data || []) as Task[];
+    let items = (data || []).map((t: any) => ({
+      ...t,
+      created: t.created ?? t.created_at,
+    })) as Task[];
 
     // Drop synthetic/meta tasks
     items = items.filter(t => t?.title && !isMeta(t));


### PR DESCRIPTION
## Summary
- normalize roadmap tasks from Supabase `roadmap_items` filtered by type
- ensure dedupe, deletion, and priority upsert operate on `roadmap_items`
- map `created_at` to `created` so tasks without priority sort by creation time

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b752e11bfc832a8d7ccd20f018444e