### PR TITLE
Use singular roadmap task type in review script

### DIFF
--- a/automation/review-repo.ts
+++ b/automation/review-repo.ts
@@ -184,7 +184,7 @@ async function main() {
     }
   };
   const roadmapIdeas = await fetchRoadmap("new");
-  const roadmapTasks = await fetchRoadmap("tasks");
+  const roadmapTasks = await fetchRoadmap("task");
   const vision = await (async () => {
     for (const rel of ["vision.md", "roadmap/vision.md"]) {
       try { return { path: rel, content: trim(await fs.readFile(path.join(TARGET_PATH, rel), "utf8"), READ_LIMIT) }; } catch {}


### PR DESCRIPTION
## Summary
- fetch roadmap items with type `task` instead of `tasks` in review automation

## Testing
- `npm test`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68b756cef710832aa73910c35860d423