### PR TITLE
Use singular roadmap task type

### DIFF
--- a/dist/cmds/review-repo.js
+++ b/dist/cmds/review-repo.js
@@ -16,7 +16,7 @@ export async function reviewRepo() {
             const data = (await sbRequest(`roadmap_items?select=content&type=eq.${type}`));
             return data ? data.map((r) => r.content).join("\n") : "";
         }
-        const roadmapTypes = ["vision", "tasks", "bugs", "done", "new"];
+        const roadmapTypes = ["vision", "task", "bugs", "done", "new"];
         const [vision, tasks, bugs, done, ideas] = await Promise.all(roadmapTypes.map(fetchRoadmap));
         const state = await loadState();
         const { owner, repo } = parseRepo(ENV.TARGET_REPO);

--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -16,7 +16,7 @@ export async function reviewRepo() {
       )) as { content: string }[] | undefined;
       return data ? data.map((r) => r.content).join("\n") : "";
     }
-    const roadmapTypes = ["vision", "tasks", "bugs", "done", "new"];
+    const roadmapTypes = ["vision", "task", "bugs", "done", "new"];
     const [vision, tasks, bugs, done, ideas] = await Promise.all(
       roadmapTypes.map(fetchRoadmap),
     );


### PR DESCRIPTION
## Summary
- fetch Supabase roadmap items using singular `task` type in review command

## Testing
- `npm test`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68b756e82d0c832a880c94ae50819256