### PR TITLE
Handle YAML parse failures in review step

### DIFF
--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -61,8 +61,14 @@ export async function reviewRepo() {
       .trim();
 
     // 3. Insert new ideas into Supabase
-    const newIdeas =
-      (yaml.load(normalizedIdeasYaml) as { queue: any[] })?.queue || [];
+    let newIdeas: any[] = [];
+    try {
+      newIdeas =
+        (yaml.load(normalizedIdeasYaml) as { queue: any[] })?.queue || [];
+    } catch (err) {
+      console.warn("Failed to parse ideas YAML; defaulting to empty array.", err);
+      console.warn("Offending YAML:\n" + normalizedIdeasYaml);
+    }
     for (const idea of newIdeas) {
       const payload = {
         id: idea.id || `IDEA-${Date.now()}`,


### PR DESCRIPTION
## Summary
- guard review repo YAML parsing with try/catch and log failures
- default to empty ideas list when YAML parsing fails so review continues

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b759d74fc4832abaf45ddd56fc2625