### PR TITLE
refactor: update roadmap table name

### DIFF
--- a/dist/lib/roadmap.js
+++ b/dist/lib/roadmap.js
@@ -1,13 +1,19 @@
 import { supabase } from "./supabase.js";
 export async function insertRoadmap(items) {
-    const { error } = await supabase.from("roadmap").insert(items);
+    const { data, error } = await supabase
+        .from("roadmap_items")
+        .insert(items)
+        .select();
     if (error)
         throw error;
+    return data ?? [];
 }
 export async function upsertRoadmap(items) {
-    const { error } = await supabase
-        .from("roadmap")
-        .upsert(items, { onConflict: "id" });
+    const { data, error } = await supabase
+        .from("roadmap_items")
+        .upsert(items, { onConflict: "id" })
+        .select();
     if (error)
         throw error;
+    return data ?? [];
 }

--- a/src/lib/roadmap.ts
+++ b/src/lib/roadmap.ts
@@ -9,14 +9,20 @@ export type RoadmapItem = {
 };
 
 export async function insertRoadmap(items: RoadmapItem[]) {
-  const { error } = await supabase.from("roadmap").insert(items);
+  const { data, error } = await supabase
+    .from("roadmap_items")
+    .insert(items)
+    .select();
   if (error) throw error;
+  return data ?? [];
 }
 
 export async function upsertRoadmap(items: RoadmapItem[]) {
-  const { error } = await supabase
-    .from("roadmap")
-    .upsert(items, { onConflict: "id" });
+  const { data, error } = await supabase
+    .from("roadmap_items")
+    .upsert(items, { onConflict: "id" })
+    .select();
   if (error) throw error;
+  return data ?? [];
 }
 


### PR DESCRIPTION
## Summary
- query roadmap_items table instead of roadmap
- return inserted/upserted data from roadmap helpers

## Testing
- `npm run build`
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b75ddcf9b8832a971eddb066f2d3f7