### PR TITLE
Add default OpenAI model fallback

### DIFF
--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -2,6 +2,15 @@
 import OpenAI from "openai";
 import { ENV, requireEnv } from "./env.js";
 
+// OpenAI requires a model name; default to a small one if unset.
+const DEFAULT_OPENAI_MODEL = "gpt-4o-mini";
+
+/** Ensure a non-empty model value before sending requests. */
+export function getModel(): string {
+  // Fall back to DEFAULT_OPENAI_MODEL so requests are always valid.
+  return ENV.OPENAI_MODEL || DEFAULT_OPENAI_MODEL;
+}
+
 /** Lazily get an OpenAI client only when needed */
 function getOpenAI() {
   requireEnv(["OPENAI_API_KEY"]);
@@ -31,7 +40,7 @@ export async function summarizeLogToBug(entries: LogEntryForBug[]): Promise<stri
     { role: "user" as const, content: JSON.stringify(entries, null, 2) }
   ];
   const r = await openai.chat.completions.create({
-    model: ENV.OPENAI_MODEL,
+    model: getModel(),
     messages
   });
   return r.choices[0]?.message?.content ?? "";
@@ -58,7 +67,7 @@ export async function reviewToSummary(input: {
     { role: "user" as const, content: JSON.stringify(input, null, 2) }
   ];
   const r = await openai.chat.completions.create({
-    model: ENV.OPENAI_MODEL,
+    model: getModel(),
     messages
   });
   return r.choices[0]?.message?.content ?? "";
@@ -88,7 +97,7 @@ export async function reviewToIdeas(input: {
       { role: "user" as const, content: JSON.stringify(input, null, 2) }
     ];
   const r = await openai.chat.completions.create({
-    model: ENV.OPENAI_MODEL,
+    model: getModel(),
     messages
   });
   return r.choices[0]?.message?.content ?? "";
@@ -117,7 +126,7 @@ export async function synthesizeTasksPrompt(input: {
     { role: "user" as const, content: JSON.stringify(input, null, 2) }
   ];
   const r = await openai.chat.completions.create({
-    model: ENV.OPENAI_MODEL,
+    model: getModel(),
     messages
   });
   return r.choices[0]?.message?.content ?? "";
@@ -152,7 +161,7 @@ export async function implementPlan(input: {
     { role: "user" as const, content: JSON.stringify(input, null, 2) }
   ];
   const r = await openai.chat.completions.create({
-    model: ENV.OPENAI_MODEL,
+    model: getModel(),
     messages
   });
   return r.choices[0]?.message?.content ?? "{}";

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -1,0 +1,19 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+
+// Tests for src/lib/prompts.ts model fallback
+
+beforeEach(() => {
+  vi.resetModules();
+  delete process.env.OPENAI_MODEL;
+});
+
+test('getModel falls back to default when env is empty', async () => {
+  const { getModel } = await import('../src/lib/prompts.ts');
+  expect(getModel()).toBe('gpt-4o-mini');
+});
+
+test('getModel uses provided env model', async () => {
+  process.env.OPENAI_MODEL = 'test-model';
+  const { getModel } = await import('../src/lib/prompts.ts');
+  expect(getModel()).toBe('test-model');
+});


### PR DESCRIPTION
## Summary
- ensure OpenAI requests always include a model, defaulting to `gpt-4o-mini` when `OPENAI_MODEL` env var is missing
- add tests for model fallback logic

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b75ef19c98832a91463a56f5577d33