### PR TITLE
feat: validate TARGET_REPO for implement

### DIFF
--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { readFile, commitMany, resolveRepoPath, ensureBranch, getDefaultBranch } from "../lib/github.js";
 import { implementPlan } from "../lib/prompts.js";
-import { ENV } from "../lib/env.js";
+import { ENV, requireEnv } from "../lib/env.js";
 
 type RoadmapItem = {
   id?: string;
@@ -17,6 +17,7 @@ type RoadmapItem = {
 export async function implementTopTask() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
+    requireEnv(['TARGET_REPO']);
     const { supabase } = await import("../lib/supabase.js");
     // Load vision for context
     const vision = (await readFile("roadmap/vision.md")) || "";

--- a/tests/implement.test.ts
+++ b/tests/implement.test.ts
@@ -1,0 +1,20 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+  delete process.env.TARGET_REPO;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('implementTopTask throws when TARGET_REPO missing', async () => {
+  vi.mock('../src/lib/lock.js', () => ({
+    acquireLock: vi.fn().mockResolvedValue(true),
+    releaseLock: vi.fn().mockResolvedValue(undefined),
+  }));
+  const { implementTopTask } = await import('../src/cmds/implement.ts');
+  await expect(implementTopTask()).rejects.toThrow('Missing env: TARGET_REPO');
+});
+


### PR DESCRIPTION
## Summary
- ensure implement command requires TARGET_REPO
- test implement command fails without TARGET_REPO

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b75f2cf218832a93c64893ed70dff1