### PR TITLE
Include Supabase response body in errors

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -37,7 +37,18 @@ export async function sbRequest(path: string, init: RequestInit = {}) {
   };
   const res = await fetch(url, { ...init, headers });
   if (!res.ok) {
-    throw new Error(`Supabase error: ${res.status} ${res.statusText}`);
+    let body = "";
+    try {
+      body = await res.text();
+    } catch {
+      // ignore
+    }
+    const snippet = body.slice(0, 100);
+    throw new Error(
+      `Supabase error: ${res.status} ${res.statusText}${
+        snippet ? ` - ${snippet}` : ""
+      }`
+    );
   }
   if (res.status === 204 || res.headers.get("Content-Length") === "0") {
     return undefined;

--- a/tests/supabase.test.ts
+++ b/tests/supabase.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+const SUPABASE_URL = 'https://example.supabase.co';
+const SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+
+beforeEach(() => {
+  vi.resetModules();
+  process.env.SUPABASE_URL = SUPABASE_URL;
+  process.env.SUPABASE_SERVICE_ROLE_KEY = SUPABASE_SERVICE_ROLE_KEY;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.SUPABASE_URL;
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+});
+
+test('sbRequest error includes response body', async () => {
+  const body = 'problem details';
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 400,
+    statusText: 'Bad Request',
+    text: async () => body,
+  } as any);
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { sbRequest } = await import('../src/lib/supabase.ts');
+  await expect(sbRequest('test')).rejects.toThrow(body);
+});
+


### PR DESCRIPTION
## Summary
- Append response body snippet to Supabase request errors
- Add unit test ensuring sbRequest surfaces response body

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b75f5cbf30832ab9461b2f5e9a36e7