### PR TITLE
Normalize and promote new Supabase ideas as tasks

### DIFF
--- a/dist/cmds/review-repo.js
+++ b/dist/cmds/review-repo.js
@@ -56,12 +56,22 @@ export async function reviewRepo() {
             .replace(/\n?```$/, "")
             .trim();
         // 3. Insert new ideas into Supabase
-        const newIdeas = yaml.load(normalizedIdeasYaml)?.queue || [];
+        let newIdeas = [];
+        try {
+            newIdeas =
+                yaml.load(normalizedIdeasYaml)?.queue || [];
+        }
+        catch (err) {
+            console.warn("Failed to parse ideas YAML; defaulting to empty array.", err);
+            console.warn("Offending YAML:\n" + normalizedIdeasYaml);
+        }
         for (const idea of newIdeas) {
             const payload = {
                 id: idea.id || `IDEA-${Date.now()}`,
-                type: "new",
-                content: yaml.dump(idea),
+                type: "task",
+                title: idea.title,
+                desc: idea.details,
+                source: "review",
                 created: idea.created || new Date().toISOString(),
             };
             await sbRequest("roadmap_items", {

--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -72,8 +72,10 @@ export async function reviewRepo() {
     for (const idea of newIdeas) {
       const payload = {
         id: idea.id || `IDEA-${Date.now()}`,
-        type: "new",
-        content: yaml.dump(idea),
+        type: "task",
+        title: idea.title,
+        desc: idea.details,
+        source: "review",
         created: idea.created || new Date().toISOString(),
       };
       await sbRequest("roadmap_items", {


### PR DESCRIPTION
## Summary
- Parse `new` Supabase roadmap entries into tasks and merge them with existing tasks while removing leftovers.
- Store repository review ideas directly as `task` entries for immediate prioritization.

## Testing
- `npm test`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68b75f8ee9c4832a8d42271f1e33f29d