### PR TITLE
fix: enable synthesize tasks persistence

### DIFF
--- a/.github/workflows/agent-synthesize-tasks.yml
+++ b/.github/workflows/agent-synthesize-tasks.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: ai-dev-agent-global
@@ -40,5 +40,5 @@ jobs:
           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          DRY_RUN: "1"
+          DRY_RUN: "0"
           ALLOW_PATHS: ""


### PR DESCRIPTION
## Summary
- allow workflow to write repo contents
- disable dry-run in synthesize tasks job

## Testing
- `npm test`
- `npm run check`
- `gh secret list` *(fails: requires authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68b75f9937c8832a9ab4417779cde3c6