### PR TITLE
refactor: default OpenAI model handling

### DIFF
--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -13,8 +13,8 @@ export function getModel(): string {
 
 /** Lazily get an OpenAI client only when needed */
 function getOpenAI() {
-  requireEnv(["OPENAI_API_KEY", "OPENAI_MODEL"]);
-  return new OpenAI({ apiKey: ENV.OPENAI_API_KEY, model: ENV.OPENAI_MODEL } as any);
+  requireEnv(["OPENAI_API_KEY"]);
+  return new OpenAI({ apiKey: ENV.OPENAI_API_KEY });
 }
 
 /** Types */


### PR DESCRIPTION
## Summary
- relax OpenAI client env requirements to only require `OPENAI_API_KEY`
- instantiate OpenAI with API key and defer model selection to `getModel()`
- test default model usage when `OPENAI_MODEL` is unset

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b762ba01b0832a9aeb252e0c5f60ea