### PR TITLE
Add tests for roadmap normalization and task synthesis

### DIFF
--- a/tests/normalize-roadmap.test.ts
+++ b/tests/normalize-roadmap.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: vi.fn() }));
+vi.mock('../src/lib/lock.js', () => ({ acquireLock: vi.fn(), releaseLock: vi.fn() }));
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('sorts and deduplicates roadmap items', async () => {
+  const rows = [
+    { id: '1', type: 'task', title: 'Task A', priority: 2, created: '2023-02-01' },
+    { id: '1', type: 'task', title: 'Task A duplicate', priority: 5, created: '2023-02-02' },
+    { id: '2', type: 'task', title: 'Task B', priority: 1, created: '2023-01-03' },
+    { id: '3', type: 'task', title: 'Task C', priority: 1, created: '2023-01-01' },
+    { id: '4', type: 'task', title: 'Task D', priority: 1, created: '2023-01-01' },
+  ];
+
+  const selectIn = vi.fn().mockResolvedValue({ data: rows, error: null });
+  const deleteIn = vi.fn().mockResolvedValue({ data: null, error: null });
+  const deleteEq = vi.fn().mockResolvedValue({ data: null, error: null });
+  const upsert = vi.fn().mockResolvedValue({ data: null, error: null });
+
+  const from = vi.fn().mockReturnValue({
+    select: vi.fn().mockReturnValue({ in: selectIn }),
+    delete: vi.fn().mockReturnValue({ in: deleteIn, eq: deleteEq }),
+    upsert,
+  });
+
+  const { createClient } = await import('@supabase/supabase-js');
+  (createClient as any).mockReturnValue({ from });
+
+  const lock = await import('../src/lib/lock.js');
+  (lock.acquireLock as any).mockResolvedValue(true);
+  (lock.releaseLock as any).mockResolvedValue(undefined);
+
+  const { normalizeRoadmap } = await import('../src/cmds/normalize-roadmap.ts');
+  await normalizeRoadmap();
+
+  expect(selectIn).toHaveBeenCalledWith('type', ['task', 'new']);
+  expect(deleteIn).toHaveBeenCalledWith('id', ['1']);
+  expect(upsert).toHaveBeenCalledWith([
+    { id: '3', type: 'task', priority: 1 },
+    { id: '4', type: 'task', priority: 2 },
+    { id: '2', type: 'task', priority: 3 },
+    { id: '1', type: 'task', priority: 4 },
+  ], { onConflict: 'id' });
+});
+
+test('propagates Supabase write errors', async () => {
+  const selectIn = vi.fn().mockResolvedValue({ data: [{ id: '1', type: 'task', title: 'T' }], error: null });
+  const deleteFn = vi.fn().mockResolvedValue({ data: null, error: null });
+  const upsert = vi.fn().mockRejectedValue(new Error('boom'));
+
+  const from = vi.fn().mockReturnValue({
+    select: vi.fn().mockReturnValue({ in: selectIn }),
+    delete: vi.fn().mockReturnValue({ in: deleteFn, eq: deleteFn }),
+    upsert,
+  });
+
+  const { createClient } = await import('@supabase/supabase-js');
+  (createClient as any).mockReturnValue({ from });
+
+  const lock = await import('../src/lib/lock.js');
+  const release = lock.releaseLock as any;
+  (lock.acquireLock as any).mockResolvedValue(true);
+  release.mockResolvedValue(undefined);
+
+  const { normalizeRoadmap } = await import('../src/cmds/normalize-roadmap.ts');
+  await expect(normalizeRoadmap()).rejects.toThrow('boom');
+  expect(release).toHaveBeenCalled();
+});
+

--- a/tests/synthesize-tasks.test.ts
+++ b/tests/synthesize-tasks.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+
+const SUPABASE_URL = 'https://example.supabase.co';
+const SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+const TARGET_REPO = 'owner/repo';
+
+beforeEach(() => {
+  vi.resetModules();
+  process.env.SUPABASE_URL = SUPABASE_URL;
+  process.env.SUPABASE_SERVICE_ROLE_KEY = SUPABASE_SERVICE_ROLE_KEY;
+  process.env.TARGET_REPO = TARGET_REPO;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.SUPABASE_URL;
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  delete process.env.TARGET_REPO;
+});
+
+test('merges tasks and orders by date', async () => {
+  vi.mock('../src/lib/lock.js', () => ({
+    acquireLock: vi.fn().mockResolvedValue(true),
+    releaseLock: vi.fn().mockResolvedValue(undefined),
+  }));
+  vi.mock('../src/lib/github.js', () => ({
+    readFile: vi.fn().mockResolvedValue('vision'),
+  }));
+  vi.mock('../src/lib/prompts.js', () => ({
+    synthesizeTasksPrompt: vi.fn().mockResolvedValue(
+`items:\n  - title: Newer\n    type: task\n    created: '2024-01-04'\n  - title: Old\n    type: task\n    created: '2024-01-03'\n  - title: Old\n    type: task\n    created: '2024-01-02'\n`),
+  }));
+
+  const fetchMock = vi.fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { id: '1', type: 'task', title: 'Existing', priority: 5, created: '2024-01-05' },
+        { id: 'x', type: 'idea', title: 'Idea', created: '2024-01-01' },
+        { id: 'y', type: 'done', content: 'finished' },
+      ],
+    } as any)
+    .mockResolvedValueOnce({ ok: true } as any)
+    .mockResolvedValueOnce({ ok: true } as any)
+    .mockResolvedValueOnce({ ok: true } as any);
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { synthesizeTasks } = await import('../src/cmds/synthesize-tasks.ts');
+  await synthesizeTasks();
+
+  const upsertCall = fetchMock.mock.calls[2];
+  const body = JSON.parse(upsertCall[1].body);
+  expect(body).toEqual([
+    { id: '1', type: 'task', title: 'Existing', priority: 1, created: '2024-01-05' },
+    { title: 'Old', type: 'task', created: '2024-01-03', priority: 2 },
+    { title: 'Newer', type: 'task', created: '2024-01-04', priority: 3 },
+  ]);
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for roadmap normalization covering sorting, dedupe, and Supabase errors
- add unit test for task synthesis merging and date ordering

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b762c0694c832aa43d5dbd1ec6879e