### PR TITLE
fix: use details column for review ideas

### DIFF
--- a/dist/cmds/review-repo.js
+++ b/dist/cmds/review-repo.js
@@ -71,7 +71,7 @@ export async function reviewRepo() {
             id: idea.id || crypto.randomUUID(),
             type: "task",
             title: idea.title,
-            desc: idea.details,
+            details: idea.details,
             source: "review",
             created: idea.created || new Date().toISOString(),
         }));

--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -75,7 +75,7 @@ export async function reviewRepo() {
       id: idea.id || crypto.randomUUID(),
       type: "task",
       title: idea.title,
-      desc: idea.details,
+      details: idea.details,
       source: "review",
       created: idea.created || new Date().toISOString(),
     }));


### PR DESCRIPTION
## Summary
- store new idea details in `details` field instead of nonexistent `desc`

## Testing
- `npm test`
- `npm run check`
- `node dist/orchestrator.js` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68b7670c9cc0832aa1033c732c4a190d