### PR TITLE
fix: broaden fallback detection for missing RPC

### DIFF
--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -16,7 +16,11 @@ export async function completeTask(task: Task) {
 
   // Try the canonical function name first
   let { error } = await supabase.rpc("complete_task", params);
-  if (error && /not found|No function/i.test(String(error.message))) {
+  if (
+    error &&
+    (error.code === "PGRST116" ||
+      /not found|No function|does not exist/i.test(String(error.message)))
+  ) {
     // Backward compatibility for older database schemas
     const { error: fallbackError } = await supabase.rpc(
       "complete_roadmap_task",


### PR DESCRIPTION
## Summary
- handle PostgREST undefined-function errors by code or message

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b7785a788c832aa4e9798b00009070