### PR TITLE
Use Supabase complete_task RPC with legacy fallback

### DIFF
--- a/dist/lib/tasks.js
+++ b/dist/lib/tasks.js
@@ -13,7 +13,7 @@ export async function completeTask(task) {
     };
     // Try the canonical function name first and fall back to the legacy name if needed.
     let { error } = await supabase.rpc("complete_task", params);
-    if (error && /not found|No function/i.test(String(error.message))) {
+    if (error && (error.code === "42883" || error.code === "PGRST302")) {
         const res = await supabase.rpc("complete_roadmap_task", params);
         if (res.error)
             throw res.error;

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -16,7 +16,7 @@ export async function completeTask(task: Task) {
 
   // Try the canonical function name first and fall back to the legacy name if needed.
   let { error } = await supabase.rpc("complete_task", params);
-  if (error && /not found|No function/i.test(String(error.message))) {
+  if (error && (error.code === "42883" || error.code === "PGRST302")) {
     const res = await supabase.rpc("complete_roadmap_task", params);
     if (res.error) throw res.error;
   } else if (error) {


### PR DESCRIPTION
## Summary
- call `complete_task` RPC and fall back to `complete_roadmap_task` if needed
- document `complete_task` as the canonical function name
- only fall back when `complete_task` RPC is undefined

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7edd7d768832ab2a0440844ec564f