### PR TITLE
Fix synthesize-tasks Supabase upsert payload

### DIFF
--- a/src/cmds/synthesize-tasks.ts
+++ b/src/cmds/synthesize-tasks.ts
@@ -38,7 +38,10 @@ export async function synthesizeTasks() {
     const url = ENV.SUPABASE_URL;
     const res = await fetch(`${url}/rest/v1/roadmap_items?select=*`, { headers });
     if (!res.ok) throw new Error(`Supabase fetch failed: ${res.status}`);
-    const rows: Task[] = await res.json();
+    const rows: Task[] = (await res.json()).map((r: any) => ({
+      ...r,
+      created: r.created ?? r.created_at,
+    }));
 
     const tasks = rows.filter(r => r.type === "task");
     const bugs  = rows.filter(r => r.type === "bug");
@@ -80,10 +83,22 @@ export async function synthesizeTasks() {
     const delTasks = await fetch(`${url}/rest/v1/roadmap_items?type=eq.task`, { method: "DELETE", headers });
     if (!delTasks.ok) throw new Error(`Supabase delete tasks failed: ${delTasks.status}`);
 
+    const toRow = (t: Task) => {
+      const row: any = {
+        title: t.title!,
+        type: "task",
+      };
+      if (t.id) row.id = t.id;
+      if (t.content || t.desc) row.content = t.content ?? t.desc;
+      if (t.priority != null) row.priority = t.priority;
+      if (t.created) row.created_at = new Date(t.created).toISOString();
+      return row;
+    };
+
     const upsert = await fetch(`${url}/rest/v1/roadmap_items`, {
       method: "POST",
       headers: { ...headers, "Content-Type": "application/json", Prefer: "resolution=merge-duplicates" },
-      body: JSON.stringify(limited.map(t => ({ ...t, type: "task" }))),
+      body: JSON.stringify(limited.map(toRow)),
     });
     if (!upsert.ok) throw new Error(`Supabase upsert tasks failed: ${upsert.status}`);
 

--- a/tests/synthesize-tasks.test.ts
+++ b/tests/synthesize-tasks.test.ts
@@ -51,9 +51,9 @@ test('merges tasks and orders by date', async () => {
   const upsertCall = fetchMock.mock.calls[2];
   const body = JSON.parse(upsertCall[1].body);
   expect(body).toEqual([
-    { id: '1', type: 'task', title: 'Existing', priority: 1, created: '2024-01-05' },
-    { title: 'Old', type: 'task', created: '2024-01-03', priority: 2 },
-    { title: 'Newer', type: 'task', created: '2024-01-04', priority: 3 },
+    { id: '1', title: 'Existing', type: 'task', priority: 1, created_at: new Date('2024-01-05').toISOString() },
+    { title: 'Old', type: 'task', priority: 2, created_at: new Date('2024-01-03').toISOString() },
+    { title: 'Newer', type: 'task', priority: 3, created_at: new Date('2024-01-04').toISOString() },
   ]);
 });
 


### PR DESCRIPTION
## Summary
- map `created_at` field and strip unknown properties before posting tasks to Supabase
- update synthesize-tasks test expectations to match sanitized payload

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b7f12a7938832a9930a41171978cf9