### PR TITLE
Fix synthesize-tasks Supabase upsert payload

### DIFF
--- a/src/cmds/synthesize-tasks.ts
+++ b/src/cmds/synthesize-tasks.ts
@@ -84,14 +84,17 @@ export async function synthesizeTasks() {
     if (!delTasks.ok) throw new Error(`Supabase delete tasks failed: ${delTasks.status}`);
 
     const toRow = (t: Task) => {
-      const row: any = {
-        title: t.title!,
-        type: "task",
-      };
-      if (t.id) row.id = t.id;
+      const row: any = t.id ? { ...t } : {};
+
+      row.title = t.title!;
+      row.type = "task";
       if (t.content || t.desc) row.content = t.content ?? t.desc;
       if (t.priority != null) row.priority = t.priority;
-      if (t.created) row.created_at = new Date(t.created).toISOString();
+      const created = (t as any).created ?? (t as any).created_at;
+      if (created) row.created_at = new Date(created).toISOString();
+
+      delete row.created;
+      delete row.desc;
       return row;
     };
 

--- a/tests/synthesize-tasks.test.ts
+++ b/tests/synthesize-tasks.test.ts
@@ -35,7 +35,7 @@ test('merges tasks and orders by date', async () => {
     .mockResolvedValueOnce({
       ok: true,
       json: async () => [
-        { id: '1', type: 'task', title: 'Existing', priority: 5, created: '2024-01-05' },
+        { id: '1', type: 'task', title: 'Existing', priority: 5, created: '2024-01-05', source: 'codex' },
         { id: 'x', type: 'idea', title: 'Idea', created: '2024-01-01' },
         { id: 'y', type: 'done', content: 'finished' },
       ],
@@ -51,7 +51,7 @@ test('merges tasks and orders by date', async () => {
   const upsertCall = fetchMock.mock.calls[2];
   const body = JSON.parse(upsertCall[1].body);
   expect(body).toEqual([
-    { id: '1', title: 'Existing', type: 'task', priority: 1, created_at: new Date('2024-01-05').toISOString() },
+    { id: '1', title: 'Existing', type: 'task', priority: 1, created_at: new Date('2024-01-05').toISOString(), source: 'codex' },
     { title: 'Old', type: 'task', priority: 2, created_at: new Date('2024-01-03').toISOString() },
     { title: 'Newer', type: 'task', priority: 3, created_at: new Date('2024-01-04').toISOString() },
   ]);


### PR DESCRIPTION
## Summary
- preserve unknown task metadata when sanitizing upsert payload
- cover metadata preservation in synthesize-tasks tests

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b7f588b580832abe0865bdbe8cc240