### PR TITLE
Handle empty task list in synthesize-tasks

### DIFF
--- a/dist/cmds/synthesize-tasks.js
+++ b/dist/cmds/synthesize-tasks.js
@@ -79,8 +79,8 @@ export async function synthesizeTasks() {
         // Unique priorities
         merged.sort(compareTasks);
         const limited = merged.slice(0, 100).map((t, i) => ({ ...t, priority: i + 1 }));
-        // Upsert tasks in Supabase
-        if (limited.length > 0) {
+        // Upsert tasks in Supabase only if new tasks were synthesized
+        if (proposed.length > 0) {
             const delTasks = await fetch(`${url}/rest/v1/roadmap_items?type=eq.task`, { method: "DELETE", headers });
             if (!delTasks.ok)
                 throw new Error(`Supabase delete tasks failed: ${delTasks.status}`);
@@ -108,7 +108,7 @@ export async function synthesizeTasks() {
                 throw new Error(`Supabase upsert tasks failed: ${upsert.status}`);
         }
         else {
-            console.log("No tasks to upsert; skipping Supabase task update.");
+            console.log("No new tasks synthesized; skipping Supabase task update.");
         }
         const delIdeas = await fetch(`${url}/rest/v1/roadmap_items?type=eq.idea`, { method: "DELETE", headers });
         if (!delIdeas.ok)

--- a/src/cmds/synthesize-tasks.ts
+++ b/src/cmds/synthesize-tasks.ts
@@ -79,8 +79,8 @@ export async function synthesizeTasks() {
     merged.sort(compareTasks);
     const limited = merged.slice(0, 100).map((t, i) => ({ ...t, priority: i + 1 }));
 
-    // Upsert tasks in Supabase
-    if (limited.length > 0) {
+    // Upsert tasks in Supabase only if new tasks were synthesized
+    if (proposed.length > 0) {
       const delTasks = await fetch(`${url}/rest/v1/roadmap_items?type=eq.task`, { method: "DELETE", headers });
       if (!delTasks.ok) throw new Error(`Supabase delete tasks failed: ${delTasks.status}`);
 
@@ -106,7 +106,7 @@ export async function synthesizeTasks() {
       });
       if (!upsert.ok) throw new Error(`Supabase upsert tasks failed: ${upsert.status}`);
     } else {
-      console.log("No tasks to upsert; skipping Supabase task update.");
+      console.log("No new tasks synthesized; skipping Supabase task update.");
     }
 
     const delIdeas = await fetch(`${url}/rest/v1/roadmap_items?type=eq.idea`, { method: "DELETE", headers });

--- a/tests/synthesize-tasks.test.ts
+++ b/tests/synthesize-tasks.test.ts
@@ -57,7 +57,7 @@ test('merges tasks and orders by date', async () => {
   ]);
 });
 
-test('skips Supabase update when no tasks generated', async () => {
+test('skips Supabase update when no tasks generated even with existing tasks', async () => {
   vi.doMock('../src/lib/lock.js', () => ({
     acquireLock: vi.fn().mockResolvedValue(true),
     releaseLock: vi.fn().mockResolvedValue(undefined),
@@ -70,7 +70,12 @@ test('skips Supabase update when no tasks generated', async () => {
   }));
 
   const fetchMock = vi.fn()
-    .mockResolvedValueOnce({ ok: true, json: async () => [] } as any)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { id: '1', type: 'task', title: 'Existing', created: '2024-01-05' },
+      ],
+    } as any)
     .mockResolvedValueOnce({ ok: true } as any);
   vi.stubGlobal('fetch', fetchMock);
 


### PR DESCRIPTION
## Summary
- prevent Supabase task deletion when no tasks are generated by skipping delete/upsert
- add regression test ensuring synthesizeTasks does not call Supabase when task list is empty
- skip Supabase update when no new tasks are generated even if existing tasks exist

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b7fd108c20832a99bffacbf415e045