### PR TITLE
Guard Supabase task updates with rollback on failure

### DIFF
--- a/src/cmds/synthesize-tasks.ts
+++ b/src/cmds/synthesize-tasks.ts
@@ -79,38 +79,49 @@ export async function synthesizeTasks() {
     merged.sort(compareTasks);
     const limited = merged.slice(0, 100).map((t, i) => ({ ...t, priority: i + 1 }));
 
+    const toRow = (t: Task) => {
+      const row: any = t.id ? { ...t } : {};
+
+      row.title = t.title!;
+      row.type = "task";
+      if (t.content || t.desc) row.content = t.content ?? t.desc;
+      if (t.priority != null) row.priority = t.priority;
+      const created = (t as any).created ?? (t as any).created_at;
+      if (created) row.created_at = new Date(created).toISOString();
+
+      delete row.created;
+      delete row.desc;
+      return row;
+    };
+
     // Upsert tasks in Supabase only if new tasks were synthesized
     if (proposed.length > 0) {
-      const delTasks = await fetch(`${url}/rest/v1/roadmap_items?type=eq.task`, { method: "DELETE", headers });
-      if (!delTasks.ok) throw new Error(`Supabase delete tasks failed: ${delTasks.status}`);
+      const backup = tasks.map(toRow);
 
-      const toRow = (t: Task) => {
-        const row: any = t.id ? { ...t } : {};
+      try {
+        const delTasks = await fetch(`${url}/rest/v1/roadmap_items?type=eq.task`, { method: "DELETE", headers });
+        if (!delTasks.ok) throw new Error(`Supabase delete tasks failed: ${delTasks.status}`);
 
-        row.title = t.title!;
-        row.type = "task";
-        if (t.content || t.desc) row.content = t.content ?? t.desc;
-        if (t.priority != null) row.priority = t.priority;
-        const created = (t as any).created ?? (t as any).created_at;
-        if (created) row.created_at = new Date(created).toISOString();
+        const upsert = await fetch(`${url}/rest/v1/roadmap_items`, {
+          method: "POST",
+          headers: { ...headers, "Content-Type": "application/json", Prefer: "resolution=merge-duplicates" },
+          body: JSON.stringify(limited.map(toRow)),
+        });
+        if (!upsert.ok) throw new Error(`Supabase upsert tasks failed: ${upsert.status}`);
+      } catch (err) {
+        await fetch(`${url}/rest/v1/roadmap_items`, {
+          method: "POST",
+          headers: { ...headers, "Content-Type": "application/json", Prefer: "resolution=merge-duplicates" },
+          body: JSON.stringify(backup),
+        });
+        throw err;
+      }
 
-        delete row.created;
-        delete row.desc;
-        return row;
-      };
-
-      const upsert = await fetch(`${url}/rest/v1/roadmap_items`, {
-        method: "POST",
-        headers: { ...headers, "Content-Type": "application/json", Prefer: "resolution=merge-duplicates" },
-        body: JSON.stringify(limited.map(toRow)),
-      });
-      if (!upsert.ok) throw new Error(`Supabase upsert tasks failed: ${upsert.status}`);
+      const delIdeas = await fetch(`${url}/rest/v1/roadmap_items?type=eq.idea`, { method: "DELETE", headers });
+      if (!delIdeas.ok) throw new Error(`Supabase delete ideas failed: ${delIdeas.status}`);
     } else {
       console.log("No new tasks synthesized; skipping Supabase task update.");
     }
-
-    const delIdeas = await fetch(`${url}/rest/v1/roadmap_items?type=eq.idea`, { method: "DELETE", headers });
-    if (!delIdeas.ok) throw new Error(`Supabase delete ideas failed: ${delIdeas.status}`);
 
     console.log(`Synthesis complete. Tasks: ${limited.length}`);
   } finally {


### PR DESCRIPTION
## Summary
- backup existing tasks before deletion
- restore tasks if Supabase upsert fails and only delete ideas after successful upsert
- add regression test for failed upsert restoration

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b81e764c6c832a81dbddf3a931bfaa