### PR TITLE
Handle colons in ideas YAML

### DIFF
--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -61,14 +61,29 @@ export async function reviewRepo() {
       .replace(/\n?```$/, "")
       .trim();
 
+    // Quote fields that may contain YAML-breaking characters (e.g., colons)
+    const sanitizedIdeasYaml = normalizedIdeasYaml.replace(
+      /^(\s*(?:-\s*)?(title|details):\s*)(.+)$/gm,
+      (_m, prefix, _field, value) => {
+        const trimmed = (value as string).trim();
+        const startsWith = trimmed[0];
+        const endsWith = trimmed[trimmed.length - 1];
+        const isQuoted = startsWith === '"' || startsWith === "'";
+        const isBalanced = isQuoted && startsWith === endsWith;
+        if (isQuoted && !isBalanced) return `${prefix}${trimmed}`;
+        const escaped = trimmed.replace(/"/g, '\\"');
+        return `${prefix}${isBalanced ? trimmed : `"${escaped}"`}`;
+      },
+    );
+
     // 3. Insert new ideas into Supabase
     let newIdeas: any[] = [];
     try {
       newIdeas =
-        (yaml.load(normalizedIdeasYaml) as { queue: any[] })?.queue || [];
+        (yaml.load(sanitizedIdeasYaml) as { queue: any[] })?.queue || [];
     } catch (err) {
       console.error("Failed to parse ideas YAML.", err);
-      console.error("Offending YAML:\n" + normalizedIdeasYaml);
+      console.error("Offending YAML:\n" + sanitizedIdeasYaml);
       throw new Error("Failed to parse ideas YAML");
     }
     const payloads = newIdeas.map((idea) => ({

--- a/tests/review-repo.test.ts
+++ b/tests/review-repo.test.ts
@@ -87,3 +87,16 @@ test('reviewRepo batches ideas and generates unique IDs', async () => {
   expect(second.id).toMatch(uuidRegex);
   expect(first.id).not.toBe(second.id);
 });
+
+test('reviewRepo handles colons in fields', async () => {
+  const { reviewRepo } = await import('../src/cmds/review-repo.ts');
+  reviewToIdeas.mockResolvedValue(
+    'queue:\n  - title: Example\n    details: Includes colon: ok\n',
+  );
+  await reviewRepo();
+  const postCalls = sbRequest.mock.calls.filter(([, init]) => init?.method === 'POST');
+  expect(postCalls).toHaveLength(2);
+  const ideasBody = JSON.parse(postCalls[1][1].body);
+  expect(ideasBody[0].title).toBe('Example');
+  expect(ideasBody[0].content).toBe('Includes colon: ok');
+});


### PR DESCRIPTION
## Summary
- sanitize generated ideas YAML by quoting `title` and `details` fields so colons don't break parsing
- add regression test for colon handling

## Testing
- `npm test`
- `npm run check`
- `node dist/orchestrator.js review-repo` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b825730ba4832a8371a64636246ae5