### PR TITLE
Handle colons in ideas YAML: skip quoting block scalars

### DIFF
--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -66,6 +66,9 @@ export async function reviewRepo() {
       /^(\s*(?:-\s*)?(title|details):\s*)(.+)$/gm,
       (_m, prefix, _field, value) => {
         const trimmed = (value as string).trim();
+        // Skip quoting YAML block scalar indicators like `|` or `>`
+        const isBlockScalar = /^[|>][0-9+-]*(?:\s+#.*)?$/.test(trimmed);
+        if (isBlockScalar) return `${prefix}${trimmed}`;
         const startsWith = trimmed[0];
         const endsWith = trimmed[trimmed.length - 1];
         const isQuoted = startsWith === '"' || startsWith === "'";

--- a/tests/review-repo.test.ts
+++ b/tests/review-repo.test.ts
@@ -100,3 +100,15 @@ test('reviewRepo handles colons in fields', async () => {
   expect(ideasBody[0].title).toBe('Example');
   expect(ideasBody[0].content).toBe('Includes colon: ok');
 });
+
+test('reviewRepo skips quoting YAML block scalars', async () => {
+  const { reviewRepo } = await import('../src/cmds/review-repo.ts');
+  reviewToIdeas.mockResolvedValue(
+    'queue:\n  - title: Example\n    details: |\n      first\n      second\n',
+  );
+  await reviewRepo();
+  const postCalls = sbRequest.mock.calls.filter(([, init]) => init?.method === 'POST');
+  expect(postCalls).toHaveLength(2);
+  const ideasBody = JSON.parse(postCalls[1][1].body);
+  expect(ideasBody[0].content).toBe('first\nsecond\n');
+});


### PR DESCRIPTION
## Summary
- avoid quoting YAML block scalar indicators to preserve multi-line fields
- add regression test for block scalar details

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b82c7049bc832aa82e682940422a38