### PR TITLE
fix: fallback to legacy task details

### DIFF
--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -9,6 +9,7 @@ type RoadmapItem = {
   id?: string;
   title?: string;
   content?: string;
+  details?: string;
   priority?: number;
   status?: string;
   type?: string;
@@ -102,7 +103,7 @@ export async function implementTopTask() {
     if (files.length) {
       // Build commit body describing root cause, scope, and validation
       const cb: any = typeof plan.commitBody === "object" ? plan.commitBody : {};
-      const rootCause = cb.rootCause || top.content || "n/a";
+      const rootCause = cb.rootCause || top.content || top.details || "n/a";
       const scope = cb.scope || files.map(f => f.path).join(", ");
       const validation = cb.validation || plan.testHint || "n/a";
       const logLink = cb.logUrl || cb.logs || cb.log || undefined;
@@ -137,7 +138,7 @@ export async function implementTopTask() {
       try {
         await commitMany(files, { title, body: commitBody }, { branch: targetBranch });
         const { completeTask } = await import("../lib/tasks.js");
-        await completeTask({ id: top.id, title: top.title, desc: top.content, priority: top.priority });
+        await completeTask({ id: top.id, title: top.title, desc: top.content ?? top.details, priority: top.priority });
         console.log("Implement complete.");
       } catch (err) {
         console.error("Bulk commit failed; no changes were applied.", err);


### PR DESCRIPTION
## Summary
- handle legacy roadmap items that still use `details`
- preserve task description when completing top task
- ensure commit body includes description if `content` missing

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b83d142ad8832a9b312a27f0194beb