### PR TITLE
Improve Supabase error reporting in task synthesis

### DIFF
--- a/src/cmds/synthesize-tasks.ts
+++ b/src/cmds/synthesize-tasks.ts
@@ -101,7 +101,10 @@ export async function synthesizeTasks() {
         headers: { ...headers, "Content-Type": "application/json", Prefer: "resolution=merge-duplicates" },
         body: JSON.stringify(limited.map(toRow)),
       });
-      if (!upsert.ok) throw new Error(`Supabase upsert tasks failed: ${upsert.status}`);
+      if (!upsert.ok) {
+        const text = (await upsert.text()).slice(0, 200);
+        throw new Error(`Supabase upsert tasks failed (${upsert.status}): ${text}`);
+      }
 
       const idsToDelete = tasks
         .filter(t => t.id && !limited.some(l => l.id === t.id))


### PR DESCRIPTION
## Summary
- Capture Supabase upsert response text and include it with the status code when an upsert fails
- Add a unit test verifying that the error message contains the Supabase response body
- Update failing test mock to provide response text

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b84b7da1f4832abcb87076735870a0