### PR TITLE
feat: add paging and timeout to vercel log fetch

### DIFF
--- a/dist/cmds/ingest-logs.js
+++ b/dist/cmds/ingest-logs.js
@@ -46,7 +46,10 @@ export async function ingestLogs() {
             console.log("No new deployment; exit.");
             return;
         }
-        const raw = await getRuntimeLogs(dep.uid);
+        const now = Date.now();
+        const from = new Date(now - 5 * 60 * 1000).toISOString();
+        const until = new Date(now).toISOString();
+        const raw = await getRuntimeLogs(dep.uid, { from, until, limit: 100, direction: "forward" });
         const entries = raw
             .filter(r => r && (r.level === "error" || r.level === "warning"))
             .map(r => ({

--- a/dist/lib/vercel.js
+++ b/dist/lib/vercel.js
@@ -21,20 +21,52 @@ export async function getLatestDeployment() {
     });
     return data.deployments?.[0];
 }
-export async function getRuntimeLogs(deploymentId) {
+export async function getRuntimeLogs(deploymentId, opts = {}) {
     if (!ENV.VERCEL_PROJECT_ID)
         return [];
     const url = new URL(`${API}/v1/projects/${ENV.VERCEL_PROJECT_ID}/deployments/${deploymentId}/runtime-logs`);
     if (ENV.VERCEL_TEAM_ID)
         url.searchParams.set("teamId", ENV.VERCEL_TEAM_ID);
-    const res = await fetch(url, { headers: { Authorization: `Bearer ${ENV.VERCEL_TOKEN}` } });
+    const { from, until, limit, direction } = opts;
+    if (from)
+        url.searchParams.set("from", from);
+    if (until)
+        url.searchParams.set("until", until);
+    if (limit !== undefined)
+        url.searchParams.set("limit", String(limit));
+    if (direction)
+        url.searchParams.set("direction", direction);
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), 30_000);
+    let res;
+    try {
+        res = await fetch(url, {
+            headers: { Authorization: `Bearer ${ENV.VERCEL_TOKEN}` },
+            signal: controller.signal
+        });
+    }
+    catch (err) {
+        if (err.name === "AbortError") {
+            throw new Error("Vercel runtime-logs request timed out");
+        }
+        throw err;
+    }
+    finally {
+        clearTimeout(t);
+    }
     if (!res.ok)
         throw new Error(`Vercel runtime-logs failed: ${res.status}`);
     const text = await res.text();
-    return text.split("\n").filter(Boolean).map(l => { try {
-        return JSON.parse(l);
-    }
-    catch {
-        return null;
-    } }).filter(Boolean);
+    return text
+        .split("\n")
+        .filter(Boolean)
+        .map(l => {
+        try {
+            return JSON.parse(l);
+        }
+        catch {
+            return null;
+        }
+    })
+        .filter(Boolean);
 }

--- a/src/cmds/ingest-logs.ts
+++ b/src/cmds/ingest-logs.ts
@@ -61,7 +61,10 @@ export async function ingestLogs(): Promise<void> {
       return;
     }
 
-    const raw = await getRuntimeLogs(dep.uid);
+    const now = Date.now();
+    const from = new Date(now - 5 * 60 * 1000).toISOString();
+    const until = new Date(now).toISOString();
+    const raw = await getRuntimeLogs(dep.uid, { from, until, limit: 100, direction: "forward" });
     const entries: RawLog[] = (raw as any[])
       .filter(r => r && (r.level === "error" || r.level === "warning"))
       .map(r => ({

--- a/src/lib/vercel.ts
+++ b/src/lib/vercel.ts
@@ -21,12 +21,53 @@ export async function getLatestDeployment() {
   return data.deployments?.[0];
 }
 
-export async function getRuntimeLogs(deploymentId: string) {
+export async function getRuntimeLogs(
+  deploymentId: string,
+  opts: {
+    from?: string;
+    until?: string;
+    limit?: number;
+    direction?: string;
+  } = {}
+) {
   if (!ENV.VERCEL_PROJECT_ID) return [];
-  const url = new URL(`${API}/v1/projects/${ENV.VERCEL_PROJECT_ID}/deployments/${deploymentId}/runtime-logs`);
+  const url = new URL(
+    `${API}/v1/projects/${ENV.VERCEL_PROJECT_ID}/deployments/${deploymentId}/runtime-logs`
+  );
   if (ENV.VERCEL_TEAM_ID) url.searchParams.set("teamId", ENV.VERCEL_TEAM_ID);
-  const res = await fetch(url, { headers: { Authorization: `Bearer ${ENV.VERCEL_TOKEN}` } });
+  const { from, until, limit, direction } = opts;
+  if (from) url.searchParams.set("from", from);
+  if (until) url.searchParams.set("until", until);
+  if (limit !== undefined) url.searchParams.set("limit", String(limit));
+  if (direction) url.searchParams.set("direction", direction);
+
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), 30_000);
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { Authorization: `Bearer ${ENV.VERCEL_TOKEN}` },
+      signal: controller.signal
+    });
+  } catch (err) {
+    if ((err as any).name === "AbortError") {
+      throw new Error("Vercel runtime-logs request timed out");
+    }
+    throw err;
+  } finally {
+    clearTimeout(t);
+  }
   if (!res.ok) throw new Error(`Vercel runtime-logs failed: ${res.status}`);
   const text = await res.text();
-  return text.split("\n").filter(Boolean).map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map(l => {
+      try {
+        return JSON.parse(l);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
 }

--- a/tests/vercel.test.ts
+++ b/tests/vercel.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+  process.env.VERCEL_PROJECT_ID = 'proj';
+  process.env.VERCEL_TOKEN = 'token';
+  process.env.VERCEL_TEAM_ID = 'team';
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  delete process.env.VERCEL_PROJECT_ID;
+  delete process.env.VERCEL_TOKEN;
+  delete process.env.VERCEL_TEAM_ID;
+});
+
+test('getRuntimeLogs passes paging params', async () => {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => '' } as any);
+  vi.stubGlobal('fetch', fetchMock);
+  const { getRuntimeLogs } = await import('../src/lib/vercel.ts');
+  await getRuntimeLogs('dep1', { from: 'a', until: 'b', limit: 5, direction: 'forward' });
+  const url = fetchMock.mock.calls[0][0] as URL;
+  expect(url.searchParams.get('from')).toBe('a');
+  expect(url.searchParams.get('until')).toBe('b');
+  expect(url.searchParams.get('limit')).toBe('5');
+  expect(url.searchParams.get('direction')).toBe('forward');
+});
+
+test('getRuntimeLogs times out', async () => {
+  vi.useFakeTimers();
+  vi.stubGlobal('fetch', vi.fn().mockImplementation((_url, opts) => {
+    return new Promise((_, reject) => {
+      opts?.signal?.addEventListener('abort', () => {
+        const err = new Error('aborted');
+        (err as any).name = 'AbortError';
+        reject(err);
+      });
+    });
+  }));
+  const { getRuntimeLogs } = await import('../src/lib/vercel.ts');
+  const p = getRuntimeLogs('dep1');
+  p.catch(() => {});
+  await vi.advanceTimersByTimeAsync(31_000);
+  await expect(p).rejects.toThrow('timed out');
+});


### PR DESCRIPTION
## Summary
- support paging options and abort controller when fetching Vercel runtime logs
- limit ingest-logs to a small time window of recent logs
- test paging params and timeout behaviour

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b84e275720832a938a17e26250340f