### PR TITLE
Whitelist payload fields for synthesized tasks upsert

### DIFF
--- a/src/cmds/synthesize-tasks.ts
+++ b/src/cmds/synthesize-tasks.ts
@@ -80,7 +80,8 @@ export async function synthesizeTasks() {
     const limited = merged.slice(0, 100).map((t, i) => ({ ...t, priority: i + 1 }));
 
     const toRow = (t: Task) => {
-      const row: any = t.id ? { ...t } : {};
+      const row: any = {};
+      if (t.id) row.id = t.id;
 
       row.title = t.title!;
       row.type = "task";
@@ -88,9 +89,7 @@ export async function synthesizeTasks() {
       if (t.priority != null) row.priority = t.priority;
       const created = (t as any).created ?? (t as any).created_at;
       if (created) row.created_at = new Date(created).toISOString();
-
-      delete row.created;
-      delete row.desc;
+      if (t.source) row.source = t.source;
       return row;
     };
 

--- a/tests/synthesize-tasks.test.ts
+++ b/tests/synthesize-tasks.test.ts
@@ -56,6 +56,43 @@ test('merges tasks and orders by date', async () => {
   ]);
 });
 
+test('filters out extra properties from existing tasks', async () => {
+  vi.doMock('../src/lib/lock.js', () => ({
+    acquireLock: vi.fn().mockResolvedValue(true),
+    releaseLock: vi.fn().mockResolvedValue(undefined),
+  }));
+  vi.doMock('../src/lib/github.js', () => ({
+    readFile: vi.fn().mockResolvedValue('vision'),
+  }));
+  vi.doMock('../src/lib/prompts.js', () => ({
+    synthesizeTasksPrompt: vi.fn().mockResolvedValue('items:\n  - title: New\n    type: task'),
+  }));
+
+  const fetchMock = vi.fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { id: '1', type: 'task', title: 'Existing', created: '2024-01-05', priority: 5, source: 'codex', extra: 'x' },
+      ],
+    } as any)
+    .mockResolvedValueOnce({ ok: true } as any)
+    .mockResolvedValueOnce({ ok: true } as any);
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { synthesizeTasks } = await import('../src/cmds/synthesize-tasks.ts');
+  await synthesizeTasks();
+
+  const body = JSON.parse(fetchMock.mock.calls[1][1].body);
+  expect(body[0]).toEqual({
+    id: '1',
+    title: 'Existing',
+    type: 'task',
+    priority: 1,
+    created_at: new Date('2024-01-05').toISOString(),
+    source: 'codex',
+  });
+});
+
 test('skips Supabase update when no tasks generated even with existing tasks', async () => {
   vi.doMock('../src/lib/lock.js', () => ({
     acquireLock: vi.fn().mockResolvedValue(true),


### PR DESCRIPTION
## Summary
- Build Supabase upsert rows from an explicit whitelist instead of cloning tasks
- Cover whitelist behavior with a unit test to ensure extra fields are stripped

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b84e5496e0832abfdce014444c49dd