### PR TITLE
classify 5-minute query limit as infrastructure

### DIFF
--- a/src/cmds/ingest-logs.ts
+++ b/src/cmds/ingest-logs.ts
@@ -34,7 +34,8 @@ function isInfraLog(e: RawLog): boolean {
     /ETIMEDOUT|ECONNRESET|ENOTFOUND|EAI_AGAIN/i,
     /failed to fetch runtime-logs/i,
     /Too Many Requests|rate limit/i,
-    /https?:\/\/api\.vercel\.com/i
+    /https?:\/\/api\.vercel\.com/i,
+    /Query exceeds 5-minute execution limit/i // exceeds Vercel's query time limit
   ];
   if (INFRA_PATTERNS.some(rx => rx.test(msg))) return true;
   if (/^https?:\/\/api\.vercel\.com/.test(path)) return true;


### PR DESCRIPTION
## Summary
- treat "Query exceeds 5-minute execution limit" as infrastructure log

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b850c3fd94832abea26c667dab8296