### PR TITLE
Persist last processed runtime log ID

### DIFF
--- a/dist/lib/vercel.js
+++ b/dist/lib/vercel.js
@@ -27,8 +27,10 @@ export async function getRuntimeLogs(deploymentId, opts = {}) {
     const url = new URL(`${API}/v1/projects/${ENV.VERCEL_PROJECT_ID}/deployments/${deploymentId}/runtime-logs`);
     if (ENV.VERCEL_TEAM_ID)
         url.searchParams.set("teamId", ENV.VERCEL_TEAM_ID);
-    const { from, until, limit, direction } = opts;
-    if (from)
+    const { fromId, from, until, limit, direction } = opts;
+    if (fromId)
+        url.searchParams.set("from", fromId);
+    else if (from)
         url.searchParams.set("from", from);
     if (until)
         url.searchParams.set("until", until);

--- a/src/cmds/ingest-logs.ts
+++ b/src/cmds/ingest-logs.ts
@@ -7,6 +7,7 @@ import { summarizeLogToBug, type LogEntryForBug } from "../lib/prompts.js";
 import { insertRoadmap, type RoadmapItem } from "../lib/roadmap.js";
 
 type RawLog = {
+  id?: string;
   level?: string;
   message?: string;
   text?: string;
@@ -57,18 +58,30 @@ export async function ingestLogs(): Promise<void> {
       return;
     }
 
-    if (state.ingest?.lastDeploymentTimestamp && dep.createdAt <= state.ingest.lastDeploymentTimestamp) {
+    if (state.ingest?.lastDeploymentTimestamp && dep.createdAt < state.ingest.lastDeploymentTimestamp) {
       console.log("No new deployment; exit.");
       return;
     }
 
-    const now = Date.now();
-    const from = new Date(now - 5 * 60 * 1000).toISOString();
-    const until = new Date(now).toISOString();
-    const raw = await getRuntimeLogs(dep.uid, { from, until, limit: 100, direction: "forward" });
-    const entries: RawLog[] = (raw as any[])
+    const sameDep = state.ingest?.lastDeploymentTimestamp === dep.createdAt;
+    const prevRowIds = sameDep ? state.ingest?.lastRowIds ?? [] : [];
+    let raw: any[] = [];
+    if (prevRowIds.length > 0) {
+      const fromId = prevRowIds[prevRowIds.length - 1];
+      raw = (await getRuntimeLogs(dep.uid, { fromId, limit: 100, direction: "forward" })) as any[];
+    } else {
+      const now = Date.now();
+      const from = new Date(now - 5 * 60 * 1000).toISOString();
+      const until = new Date(now).toISOString();
+      raw = (await getRuntimeLogs(dep.uid, { from, until, limit: 100, direction: "forward" })) as any[];
+    }
+    const rawIds = raw.map(r => r?.id).filter(Boolean) as string[];
+    const prevIds = new Set(prevRowIds);
+    const entries: RawLog[] = raw
       .filter(r => r && (r.level === "error" || r.level === "warning"))
+      .filter(r => !prevIds.has(r.id))
       .map(r => ({
+        id: r.id,
         level: r.level,
         message: r.message ?? r.text ?? "",
         requestPath: r.requestPath ?? "",
@@ -77,7 +90,7 @@ export async function ingestLogs(): Promise<void> {
 
     if (entries.length === 0) {
       console.log("No relevant log entries.");
-      await saveState({ ...state, ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: [] } });
+      await saveState({ ...state, ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: rawIds } });
       return;
     }
 
@@ -96,7 +109,7 @@ export async function ingestLogs(): Promise<void> {
         created: new Date().toISOString()
       };
       await insertRoadmap([item]);
-      await saveState({ ...state, ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: [] } });
+      await saveState({ ...state, ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: rawIds } });
       await appendChangelog("Handled infra-only logs during ingestion.");
       await appendDecision("Routed infra-related logs to Supabase as ideas instead of bugs.");
       console.log("Infra-only logs detected; routed to Supabase as type=idea.");
@@ -105,7 +118,7 @@ export async function ingestLogs(): Promise<void> {
 
     if (appEntries.length === 0) {
       console.log("No application log entries to process.");
-      await saveState({ ...state, ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: [] } });
+      await saveState({ ...state, ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: rawIds } });
       await appendChangelog("Ingestion run found no application logs.");
       await appendDecision("No app logs to process from latest deployment.");
       return;
@@ -146,7 +159,7 @@ export async function ingestLogs(): Promise<void> {
 
     await insertRoadmap(items);
 
-    await saveState({ ...state, ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: [] } });
+    await saveState({ ...state, ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: rawIds } });
     await appendChangelog("Ingested runtime logs and inserted bugs into Supabase.");
     await appendDecision("Processed runtime logs and updated state after ingestion.");
     console.log("Ingest complete.");

--- a/src/lib/vercel.ts
+++ b/src/lib/vercel.ts
@@ -24,6 +24,7 @@ export async function getLatestDeployment() {
 export async function getRuntimeLogs(
   deploymentId: string,
   opts: {
+    fromId?: string;
     from?: string;
     until?: string;
     limit?: number;
@@ -35,8 +36,9 @@ export async function getRuntimeLogs(
     `${API}/v1/projects/${ENV.VERCEL_PROJECT_ID}/deployments/${deploymentId}/runtime-logs`
   );
   if (ENV.VERCEL_TEAM_ID) url.searchParams.set("teamId", ENV.VERCEL_TEAM_ID);
-  const { from, until, limit, direction } = opts;
-  if (from) url.searchParams.set("from", from);
+  const { fromId, from, until, limit, direction } = opts;
+  if (fromId) url.searchParams.set("from", fromId);
+  else if (from) url.searchParams.set("from", from);
   if (until) url.searchParams.set("until", until);
   if (limit !== undefined) url.searchParams.set("limit", String(limit));
   if (direction) url.searchParams.set("direction", direction);

--- a/tests/ingest-logs.test.ts
+++ b/tests/ingest-logs.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('ingestLogs only fetches new log entries on repeat runs', async () => {
+  vi.mock('../src/lib/lock.js', () => ({
+    acquireLock: vi.fn().mockResolvedValue(true),
+    releaseLock: vi.fn().mockResolvedValue(undefined),
+  }));
+  vi.mock('../src/lib/state.js', () => ({
+    loadState: vi.fn(),
+    saveState: vi.fn(),
+    appendChangelog: vi.fn(),
+    appendDecision: vi.fn(),
+  }));
+  vi.mock('../src/lib/vercel.js', () => ({
+    getLatestDeployment: vi.fn(),
+    getRuntimeLogs: vi.fn(),
+  }));
+  vi.mock('../src/lib/prompts.js', () => ({ summarizeLogToBug: vi.fn().mockResolvedValue('# t\ncontent') }));
+  vi.mock('../src/lib/roadmap.js', () => ({ insertRoadmap: vi.fn() }));
+
+  const { ingestLogs } = await import('../src/cmds/ingest-logs.ts');
+  const { getLatestDeployment, getRuntimeLogs } = await import('../src/lib/vercel.js');
+  const { loadState, saveState } = await import('../src/lib/state.js');
+  const { insertRoadmap } = await import('../src/lib/roadmap.js');
+
+  loadState
+    .mockResolvedValueOnce({})
+    .mockResolvedValueOnce({ ingest: { lastDeploymentTimestamp: 1, lastRowIds: ['id1', 'id2'] } });
+  getLatestDeployment.mockResolvedValue({ uid: 'dep1', createdAt: 1 });
+  getRuntimeLogs
+    .mockResolvedValueOnce([
+      { id: 'id1', level: 'error', message: 'a' },
+      { id: 'id2', level: 'error', message: 'b' },
+    ])
+    .mockResolvedValueOnce([
+      { id: 'id2', level: 'error', message: 'b' },
+      { id: 'id3', level: 'error', message: 'c' },
+    ]);
+
+  await ingestLogs();
+  await ingestLogs();
+
+  expect(getRuntimeLogs.mock.calls[1][1]).toEqual(
+    expect.objectContaining({ fromId: 'id2' })
+  );
+  expect(insertRoadmap.mock.calls[0][0]).toHaveLength(2);
+  expect(insertRoadmap.mock.calls[1][0]).toHaveLength(1);
+  expect(saveState.mock.calls[1][0].ingest.lastRowIds).toEqual(['id2', 'id3']);
+});

--- a/tests/vercel.test.ts
+++ b/tests/vercel.test.ts
@@ -27,6 +27,15 @@ test('getRuntimeLogs passes paging params', async () => {
   expect(url.searchParams.get('direction')).toBe('forward');
 });
 
+test('getRuntimeLogs uses fromId when provided', async () => {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => '' } as any);
+  vi.stubGlobal('fetch', fetchMock);
+  const { getRuntimeLogs } = await import('../src/lib/vercel.ts');
+  await getRuntimeLogs('dep1', { fromId: '123' });
+  const url = fetchMock.mock.calls[0][0] as URL;
+  expect(url.searchParams.get('from')).toBe('123');
+});
+
 test('getRuntimeLogs times out', async () => {
   vi.useFakeTimers();
   vi.stubGlobal('fetch', vi.fn().mockImplementation((_url, opts) => {


### PR DESCRIPTION
## Summary
- store last processed log identifiers in agent state and fetch logs only after the saved ID
- extend Vercel runtime log API helper with `fromId` support
- test that log ingestion skips previously seen entries

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b8527ddeb8832ab333bb959132ca63