### PR TITLE
Ensure consistent task row structure

### DIFF
--- a/dist/cmds/synthesize-tasks.js
+++ b/dist/cmds/synthesize-tasks.js
@@ -82,7 +82,7 @@ export async function synthesizeTasks() {
         const toRow = (t) => {
             const created = t.created ?? t.created_at;
             return {
-                id: t.id ?? null,
+                ...(t.id !== undefined ? { id: t.id } : {}),
                 title: t.title ?? null,
                 type: "task",
                 content: t.content ?? t.desc ?? null,

--- a/src/cmds/synthesize-tasks.ts
+++ b/src/cmds/synthesize-tasks.ts
@@ -82,7 +82,7 @@ export async function synthesizeTasks() {
     const toRow = (t: Task) => {
       const created = (t as any).created ?? (t as any).created_at;
       return {
-        id: t.id ?? null,
+        ...(t.id !== undefined ? { id: t.id } : {}),
         title: t.title ?? null,
         type: "task",
         content: t.content ?? t.desc ?? null,

--- a/tests/synthesize-tasks.test.ts
+++ b/tests/synthesize-tasks.test.ts
@@ -49,7 +49,7 @@ test('merges tasks and orders by date', async () => {
 
   const upsertCall = fetchMock.mock.calls[1];
   const body = JSON.parse(upsertCall[1].body);
-  const keys = ['id', 'title', 'type', 'content', 'priority', 'created_at', 'source'];
+  const keys = ['title', 'type', 'content', 'priority', 'created_at', 'source'];
   expect(body).toEqual([
     {
       id: '1',
@@ -61,7 +61,6 @@ test('merges tasks and orders by date', async () => {
       source: 'codex',
     },
     {
-      id: null,
       title: 'Old',
       type: 'task',
       content: null,
@@ -70,7 +69,6 @@ test('merges tasks and orders by date', async () => {
       source: null,
     },
     {
-      id: null,
       title: 'Newer',
       type: 'task',
       content: null,
@@ -79,7 +77,9 @@ test('merges tasks and orders by date', async () => {
       source: null,
     },
   ]);
-  expect(body.every(o => Object.keys(o).length === keys.length && keys.every(k => k in o))).toBe(true);
+  expect(body[0]).toHaveProperty('id');
+  expect(body.slice(1).every(o => !('id' in o))).toBe(true);
+  expect(body.every(o => keys.every(k => k in o))).toBe(true);
 });
 
 test('filters out extra properties from existing tasks', async () => {


### PR DESCRIPTION
## Summary
- Only include `id` in upsert payload when defined to avoid null IDs
- Update tests for optional `id`

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b85a2b52d4832abb6b345513239f04