### PR TITLE
test: enforce consistent task payload keys

### DIFF
--- a/tests/synthesize-tasks.test.ts
+++ b/tests/synthesize-tasks.test.ts
@@ -49,6 +49,9 @@ test('merges tasks and orders by date', async () => {
 
   const upsertCall = fetchMock.mock.calls[1];
   const body = JSON.parse(upsertCall[1].body);
+  const sortedKeys = (o: any) => Object.keys(o).filter(k => k !== 'id').sort();
+  const baseKeys = sortedKeys(body[0]);
+  expect(body.every(o => sortedKeys(o).join(',') === baseKeys.join(','))).toBe(true);
   const keys = ['title', 'type', 'content', 'priority', 'created_at', 'source'];
   expect(body).toEqual([
     {


### PR DESCRIPTION
## Summary
- ensure synthesized task payloads share the same set of keys

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b85c806070832a964d180795f5dda8