### PR TITLE
Handle Vercel log API timeouts

### DIFF
--- a/dist/lib/vercel.js
+++ b/dist/lib/vercel.js
@@ -49,7 +49,8 @@ export async function getRuntimeLogs(deploymentId, opts = {}) {
     }
     catch (err) {
         if (err.name === "AbortError") {
-            throw new Error("Vercel runtime-logs request timed out");
+            console.warn("Vercel runtime-logs request timed out");
+            return [];
         }
         throw err;
     }

--- a/src/lib/vercel.ts
+++ b/src/lib/vercel.ts
@@ -53,7 +53,8 @@ export async function getRuntimeLogs(
     });
   } catch (err) {
     if ((err as any).name === "AbortError") {
-      throw new Error("Vercel runtime-logs request timed out");
+      console.warn("Vercel runtime-logs request timed out");
+      return [];
     }
     throw err;
   } finally {

--- a/tests/vercel.test.ts
+++ b/tests/vercel.test.ts
@@ -36,7 +36,7 @@ test('getRuntimeLogs uses fromId when provided', async () => {
   expect(url.searchParams.get('from')).toBe('123');
 });
 
-test('getRuntimeLogs times out', async () => {
+test('getRuntimeLogs returns empty array on timeout', async () => {
   vi.useFakeTimers();
   vi.stubGlobal('fetch', vi.fn().mockImplementation((_url, opts) => {
     return new Promise((_, reject) => {
@@ -49,7 +49,6 @@ test('getRuntimeLogs times out', async () => {
   }));
   const { getRuntimeLogs } = await import('../src/lib/vercel.ts');
   const p = getRuntimeLogs('dep1');
-  p.catch(() => {});
   await vi.advanceTimersByTimeAsync(31_000);
-  await expect(p).rejects.toThrow('timed out');
+  await expect(p).resolves.toEqual([]);
 });


### PR DESCRIPTION
## Summary
- return empty array if Vercel runtime log fetch is aborted
- cover timeout case in tests

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b85eaf699c832a8ff301fd21374730