### PR TITLE
Handle Vercel log API timeouts

### DIFF
--- a/dist/lib/vercel.js
+++ b/dist/lib/vercel.js
@@ -50,7 +50,6 @@ export async function getRuntimeLogs(deploymentId, opts = {}) {
     catch (err) {
         if (err.name === "AbortError") {
             console.warn("Vercel runtime-logs request timed out");
-            return [];
         }
         throw err;
     }

--- a/src/lib/vercel.ts
+++ b/src/lib/vercel.ts
@@ -54,7 +54,6 @@ export async function getRuntimeLogs(
   } catch (err) {
     if ((err as any).name === "AbortError") {
       console.warn("Vercel runtime-logs request timed out");
-      return [];
     }
     throw err;
   } finally {

--- a/tests/vercel.test.ts
+++ b/tests/vercel.test.ts
@@ -36,7 +36,7 @@ test('getRuntimeLogs uses fromId when provided', async () => {
   expect(url.searchParams.get('from')).toBe('123');
 });
 
-test('getRuntimeLogs returns empty array on timeout', async () => {
+test('getRuntimeLogs rejects on timeout', async () => {
   vi.useFakeTimers();
   vi.stubGlobal('fetch', vi.fn().mockImplementation((_url, opts) => {
     return new Promise((_, reject) => {
@@ -48,7 +48,7 @@ test('getRuntimeLogs returns empty array on timeout', async () => {
     });
   }));
   const { getRuntimeLogs } = await import('../src/lib/vercel.ts');
-  const p = getRuntimeLogs('dep1');
+  const p = expect(getRuntimeLogs('dep1')).rejects.toMatchObject({ name: 'AbortError' });
   await vi.advanceTimersByTimeAsync(31_000);
-  await expect(p).resolves.toEqual([]);
+  await p;
 });


### PR DESCRIPTION
## Summary
- warn and propagate Vercel runtime log timeouts instead of returning empty logs
- update timeout test to expect rejection

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b8608cb084832a9af48fc1a41fd3eb