### PR TITLE
refactor: use created column for roadmap items

### DIFF
--- a/dist/cmds/normalize-roadmap.js
+++ b/dist/cmds/normalize-roadmap.js
@@ -34,7 +34,7 @@ export async function normalizeRoadmap() {
         let items = (data || []).map((t) => {
             let item = {
                 ...t,
-                created: t.created ?? t.created_at,
+                created: t.created,
                 desc: t.desc ?? t.content ?? t.details,
             };
             if (t.type === "new") {

--- a/dist/cmds/synthesize-tasks.js
+++ b/dist/cmds/synthesize-tasks.js
@@ -40,7 +40,7 @@ export async function synthesizeTasks() {
             throw new Error(`Supabase fetch failed: ${res.status}`);
         const rows = (await res.json()).map((r) => ({
             ...r,
-            created: r.created ?? r.created_at,
+            created: r.created,
         }));
         const tasks = rows.filter(r => r.type === "task");
         const bugs = rows.filter(r => r.type === "bug");
@@ -80,27 +80,55 @@ export async function synthesizeTasks() {
         merged.sort(compareTasks);
         const limited = merged.slice(0, 100).map((t, i) => ({ ...t, priority: i + 1 }));
         const toRow = (t) => {
-            const created = t.created ?? t.created_at;
+            const created = t.created;
             return {
-                ...(t.id !== undefined ? { id: t.id } : {}),
+                id: t.id ?? null,
                 title: t.title ?? null,
                 type: "task",
                 content: t.content ?? t.desc ?? null,
                 priority: t.priority ?? null,
-                created_at: created ? new Date(created).toISOString() : null,
+                created: created ? new Date(created).toISOString() : null,
                 source: t.source ?? null,
             };
         };
         // Upsert tasks in Supabase only if new tasks were synthesized
         if (proposed.length > 0) {
-            const upsert = await fetch(`${url}/rest/v1/roadmap_items`, {
-                method: "POST",
-                headers: { ...headers, "Content-Type": "application/json", Prefer: "resolution=merge-duplicates" },
-                body: JSON.stringify(limited.map(toRow)),
-            });
-            if (!upsert.ok) {
-                const text = (await upsert.text()).slice(0, 200);
-                throw new Error(`Supabase upsert tasks failed (${upsert.status}): ${text}`);
+            const rows = limited.map(toRow);
+            const toUpdate = rows.filter(r => r.id !== null);
+            const toInsert = rows.filter(r => r.id === null).map(({ id, ...rest }) => rest);
+            const hasUniformKeys = (arr) => {
+                if (arr.length <= 1)
+                    return true;
+                const keys = Object.keys(arr[0]).sort();
+                return arr.every(r => {
+                    const k = Object.keys(r).sort();
+                    return k.length === keys.length && k.every((v, i) => v === keys[i]);
+                });
+            };
+            if (!hasUniformKeys(toUpdate) || !hasUniformKeys(toInsert)) {
+                throw new Error("Non-uniform keys in Supabase task payload");
+            }
+            if (toUpdate.length) {
+                const upsert = await fetch(`${url}/rest/v1/roadmap_items`, {
+                    method: "POST",
+                    headers: { ...headers, "Content-Type": "application/json", Prefer: "resolution=merge-duplicates" },
+                    body: JSON.stringify(toUpdate),
+                });
+                if (!upsert.ok) {
+                    const text = (await upsert.text()).slice(0, 200);
+                    throw new Error(`Supabase upsert tasks failed (${upsert.status}): ${text}`);
+                }
+            }
+            if (toInsert.length) {
+                const insert = await fetch(`${url}/rest/v1/roadmap_items`, {
+                    method: "POST",
+                    headers: { ...headers, "Content-Type": "application/json" },
+                    body: JSON.stringify(toInsert),
+                });
+                if (!insert.ok) {
+                    const text = (await insert.text()).slice(0, 200);
+                    throw new Error(`Supabase insert tasks failed (${insert.status}): ${text}`);
+                }
             }
             const idsToDelete = tasks
                 .filter(t => t.id && !limited.some(l => l.id === t.id))

--- a/docs/supabase-schema.md
+++ b/docs/supabase-schema.md
@@ -11,7 +11,7 @@ The `roadmap_items` table is the canonical backlog and replaces the older `tasks
 | content    | text                                                | optional |
 | type       | enum ('idea','task','bug','done'), not null         | |
 | priority   | integer                                             | optional |
-| created_at | timestamptz, default timezone('utc', now())         | |
+| created | timestamptz, default timezone('utc', now())         | |
 | status     | text                                                | optional |
 
 ### Indices
@@ -30,12 +30,18 @@ create table roadmap_items (
   content text,
   type roadmap_item_type not null,
   priority int,
-  created_at timestamptz default timezone('utc', now()),
+  created timestamptz default timezone('utc', now()),
   status text
 );
 
 create index roadmap_items_type_idx on roadmap_items(type);
 create index roadmap_items_priority_idx on roadmap_items(priority);
+```
+
+Older deployments may still use a `created_at` column. To migrate:
+
+```sql
+alter table roadmap_items rename column created_at to created;
 ```
 
 

--- a/src/cmds/normalize-roadmap.ts
+++ b/src/cmds/normalize-roadmap.ts
@@ -32,7 +32,7 @@ export async function normalizeRoadmap() {
     let items = (data || []).map((t: any) => {
       let item: Task = {
         ...t,
-        created: t.created ?? t.created_at,
+        created: t.created,
         desc: t.desc ?? t.content ?? t.details,
       };
       if (t.type === "new") {

--- a/src/cmds/synthesize-tasks.ts
+++ b/src/cmds/synthesize-tasks.ts
@@ -40,7 +40,7 @@ export async function synthesizeTasks() {
     if (!res.ok) throw new Error(`Supabase fetch failed: ${res.status}`);
     const rows: Task[] = (await res.json()).map((r: any) => ({
       ...r,
-      created: r.created ?? r.created_at,
+      created: r.created,
     }));
 
     const tasks = rows.filter(r => r.type === "task");
@@ -80,14 +80,14 @@ export async function synthesizeTasks() {
     const limited = merged.slice(0, 100).map((t, i) => ({ ...t, priority: i + 1 }));
 
     const toRow = (t: Task) => {
-      const created = (t as any).created ?? (t as any).created_at;
+      const created = (t as any).created;
       return {
         id: t.id ?? null,
         title: t.title ?? null,
         type: "task",
         content: t.content ?? t.desc ?? null,
         priority: t.priority ?? null,
-        created_at: created ? new Date(created).toISOString() : null,
+        created: created ? new Date(created).toISOString() : null,
         source: t.source ?? null,
       };
     };

--- a/tests/synthesize-tasks.test.ts
+++ b/tests/synthesize-tasks.test.ts
@@ -50,7 +50,7 @@ test('merges tasks and orders by date', async () => {
 
   const updateBody = JSON.parse(fetchMock.mock.calls[1][1].body);
   const insertBody = JSON.parse(fetchMock.mock.calls[2][1].body);
-  const keys = ['title', 'type', 'content', 'priority', 'created_at', 'source'];
+  const keys = ['title', 'type', 'content', 'priority', 'created', 'source'];
 
   expect(updateBody).toEqual([
     {
@@ -59,7 +59,7 @@ test('merges tasks and orders by date', async () => {
       type: 'task',
       content: null,
       priority: 1,
-      created_at: new Date('2024-01-05').toISOString(),
+      created: new Date('2024-01-05').toISOString(),
       source: 'codex',
     },
   ]);
@@ -71,7 +71,7 @@ test('merges tasks and orders by date', async () => {
       type: 'task',
       content: null,
       priority: 2,
-      created_at: new Date('2024-01-03').toISOString(),
+      created: new Date('2024-01-03').toISOString(),
       source: null,
     },
     {
@@ -79,7 +79,7 @@ test('merges tasks and orders by date', async () => {
       type: 'task',
       content: null,
       priority: 3,
-      created_at: new Date('2024-01-04').toISOString(),
+      created: new Date('2024-01-04').toISOString(),
       source: null,
     },
   ]);
@@ -117,14 +117,14 @@ test('filters out extra properties from existing tasks', async () => {
   await synthesizeTasks();
 
   const body = JSON.parse(fetchMock.mock.calls[1][1].body);
-  const keys = ['id', 'title', 'type', 'content', 'priority', 'created_at', 'source'];
+  const keys = ['id', 'title', 'type', 'content', 'priority', 'created', 'source'];
   expect(body[0]).toEqual({
     id: '1',
     title: 'Existing',
     type: 'task',
     content: null,
     priority: 1,
-    created_at: new Date('2024-01-05').toISOString(),
+    created: new Date('2024-01-05').toISOString(),
     source: 'codex',
   });
   expect(Object.keys(body[0])).toEqual(keys);


### PR DESCRIPTION
## Summary
- switch synthesize-tasks to write `created` instead of `created_at`
- align roadmap normalization and tests with `created` column
- document `roadmap_items` `created` column and migration from `created_at`

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b869ff510c832a8c26bd92163c2b5b