### PR TITLE
refactor: use sbRequest for task synthesis

### DIFF
--- a/src/cmds/synthesize-tasks.ts
+++ b/src/cmds/synthesize-tasks.ts
@@ -2,7 +2,8 @@ import yaml from "js-yaml";
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { readFile } from "../lib/github.js";
 import { synthesizeTasksPrompt } from "../lib/prompts.js";
-import { ENV, requireEnv } from "../lib/env.js";
+import { requireEnv } from "../lib/env.js";
+import { sbRequest } from "../lib/supabase.js";
 
 type Task = { id?: string; type?: string; title?: string; desc?: string; content?: string; source?: string; created?: string | number | Date; priority?: number };
 
@@ -34,11 +35,7 @@ export async function synthesizeTasks() {
 
     const vision = (await readFile("roadmap/vision.md")) || "";
 
-    const headers = { apikey: ENV.SUPABASE_SERVICE_ROLE_KEY, Authorization: `Bearer ${ENV.SUPABASE_SERVICE_ROLE_KEY}` };
-    const url = ENV.SUPABASE_URL;
-    const res = await fetch(`${url}/rest/v1/roadmap_items?select=*`, { headers });
-    if (!res.ok) throw new Error(`Supabase fetch failed: ${res.status}`);
-    const rows: Task[] = (await res.json()).map((r: any) => ({
+    const rows: Task[] = ((await sbRequest("roadmap_items?select=*")) as any[]).map((r: any) => ({
       ...r,
       created: r.created,
     }));
@@ -117,42 +114,28 @@ export async function synthesizeTasks() {
       }
 
       if (toUpdate.length) {
-        const upsert = await fetch(`${url}/rest/v1/roadmap_items`, {
+        await sbRequest("roadmap_items", {
           method: "POST",
-          headers: { ...headers, "Content-Type": "application/json", Prefer: "resolution=merge-duplicates" },
+          headers: { Prefer: "resolution=merge-duplicates" },
           body: JSON.stringify(toUpdate),
         });
-        if (!upsert.ok) {
-          const text = (await upsert.text()).slice(0, 200);
-          throw new Error(`Supabase upsert tasks failed (${upsert.status}): ${text}`);
-        }
       }
 
       if (toInsert.length) {
-        const insert = await fetch(`${url}/rest/v1/roadmap_items`, {
+        await sbRequest("roadmap_items", {
           method: "POST",
-          headers: { ...headers, "Content-Type": "application/json" },
           body: JSON.stringify(toInsert),
         });
-        if (!insert.ok) {
-          const text = (await insert.text()).slice(0, 200);
-          throw new Error(`Supabase insert tasks failed (${insert.status}): ${text}`);
-        }
       }
 
       const idsToDelete = tasks
         .filter(t => t.id && !limited.some(l => l.id === t.id))
         .map(t => `'${t.id}'`);
       if (idsToDelete.length) {
-        const delTasks = await fetch(
-          `${url}/rest/v1/roadmap_items?id=in.(${idsToDelete.join(',')})`,
-          { method: "DELETE", headers }
-        );
-        if (!delTasks.ok) throw new Error(`Supabase delete tasks failed: ${delTasks.status}`);
+        await sbRequest(`roadmap_items?id=in.(${idsToDelete.join(',')})`, { method: "DELETE" });
       }
 
-      const delIdeas = await fetch(`${url}/rest/v1/roadmap_items?type=eq.idea`, { method: "DELETE", headers });
-      if (!delIdeas.ok) throw new Error(`Supabase delete ideas failed: ${delIdeas.status}`);
+      await sbRequest("roadmap_items?type=eq.idea", { method: "DELETE" });
     } else {
       console.log("No new tasks synthesized; skipping Supabase task update.");
     }


### PR DESCRIPTION
## Summary
- refactor task synthesis to use shared `sbRequest` helper and drop manual headers
- adjust Supabase requests for new interface
- test that `sbRequest` errors bubble up during synthesis

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b87b80edf8832ab56ebf7757baf235