### PR TITLE
scope: include repo in roadmap items

### DIFF
--- a/automation/review-repo.ts
+++ b/automation/review-repo.ts
@@ -185,7 +185,7 @@ async function main() {
   const trim = (s: string, n: number) => (s && s.length > n ? s.slice(0, n) : (s || ""));
   const READ_LIMIT = 8000;
   const fetchRoadmap = async (type: string) => {
-    const url = `${process.env.SUPABASE_URL}/rest/v1/roadmap_items?select=content&type=eq.${type}`;
+    const url = `${process.env.SUPABASE_URL}/rest/v1/roadmap_items?select=content&type=eq.${type}&repo=eq.${process.env.TARGET_REPO}`;
     const headers = {
       apikey: process.env.SUPABASE_SERVICE_ROLE_KEY || "",
       Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY || ""}`,
@@ -273,6 +273,7 @@ async function main() {
       type: "new",
       content: output,
       created: new Date().toISOString(),
+      repo: process.env.TARGET_REPO,
     }),
   });
   if (!resp.ok) {

--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -28,6 +28,7 @@ export async function implementTopTask() {
       .from("roadmap_items")
       .select("*")
       .eq("type", "task")
+      .eq("repo", ENV.TARGET_REPO)
       .or("status.is.null,status.neq.done")
       .order("priority", { ascending: true })
       .limit(1);

--- a/src/cmds/normalize-roadmap.ts
+++ b/src/cmds/normalize-roadmap.ts
@@ -27,7 +27,8 @@ export async function normalizeRoadmap() {
     const { data, error } = await supabase
       .from("roadmap_items")
       .select("*")
-      .in("type", ["task", "new"]);
+      .in("type", ["task", "new"])
+      .eq("repo", ENV.TARGET_REPO);
     if (error) throw error;
     let items = (data || []).map((t: any) => {
       let item: Task = {
@@ -70,7 +71,8 @@ export async function normalizeRoadmap() {
       const { error: delError } = await supabase
         .from("roadmap_items")
         .delete()
-        .in("id", dupIds);
+        .in("id", dupIds)
+        .eq("repo", ENV.TARGET_REPO);
       if (delError) throw delError;
     }
 
@@ -80,6 +82,7 @@ export async function normalizeRoadmap() {
       id: t.id!,
       type: "task",
       priority: i < 100 ? i + 1 : null,
+      repo: ENV.TARGET_REPO,
     }));
     if (updates.length) {
       const { error: upsertError } = await supabase
@@ -92,7 +95,8 @@ export async function normalizeRoadmap() {
     const { error: finalDelError } = await supabase
       .from("roadmap_items")
       .delete()
-      .eq("type", "new");
+      .eq("type", "new")
+      .eq("repo", ENV.TARGET_REPO);
     if (finalDelError) throw finalDelError;
 
     console.log(

--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -13,7 +13,7 @@ export async function reviewRepo() {
     requireEnv(["TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
     async function fetchRoadmap(type: string) {
       const data = (await sbRequest(
-        `roadmap_items?select=content&type=eq.${type}`,
+        `roadmap_items?select=content&type=eq.${type}&repo=eq.${ENV.TARGET_REPO}`,
       )) as { content: string }[] | undefined;
       return data ? data.map((r) => r.content).join("\n") : "";
     }
@@ -47,6 +47,7 @@ export async function reviewRepo() {
         type: "summary",
         content: summary,
         created: new Date().toISOString(),
+        repo: ENV.TARGET_REPO,
       }),
     });
     console.log("Stored repo summary in Supabase.");
@@ -96,6 +97,7 @@ export async function reviewRepo() {
       content: idea.details,
       source: "review",
       created: idea.created || new Date().toISOString(),
+      repo: ENV.TARGET_REPO,
     }));
     if (payloads.length > 0) {
       await sbRequest("roadmap_items", {

--- a/src/lib/roadmap.ts
+++ b/src/lib/roadmap.ts
@@ -1,4 +1,5 @@
 import { supabase } from "./supabase.js";
+import { ENV } from "./env.js";
 
 export type RoadmapItem = {
   id: string;
@@ -6,21 +7,24 @@ export type RoadmapItem = {
   title: string;
   content: string;
   created: string;
+  repo?: string;
 };
 
 export async function insertRoadmap(items: RoadmapItem[]) {
+  const withRepo = items.map(i => ({ ...i, repo: ENV.TARGET_REPO }));
   const { data, error } = await supabase
     .from("roadmap_items")
-    .insert(items)
+    .insert(withRepo)
     .select();
   if (error) throw error;
   return data ?? [];
 }
 
 export async function upsertRoadmap(items: RoadmapItem[]) {
+  const withRepo = items.map(i => ({ ...i, repo: ENV.TARGET_REPO }));
   const { data, error } = await supabase
     .from("roadmap_items")
-    .upsert(items, { onConflict: "id" })
+    .upsert(withRepo, { onConflict: "id" })
     .select();
   if (error) throw error;
   return data ?? [];

--- a/tests/roadmap.test.ts
+++ b/tests/roadmap.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+  process.env.TARGET_REPO = 'owner/repo';
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.TARGET_REPO;
+});
+
+test('insertRoadmap and upsertRoadmap attach repo', async () => {
+  const select = vi.fn().mockResolvedValue({ data: [], error: null });
+  const insert = vi.fn().mockReturnValue({ select });
+  const upsert = vi.fn().mockReturnValue({ select });
+    const from = vi.fn().mockReturnValue({ insert, upsert });
+    vi.doMock('../src/lib/supabase.js', () => ({ supabase: { from } }));
+
+  const { insertRoadmap, upsertRoadmap } = await import('../src/lib/roadmap.ts');
+  await insertRoadmap([{ id: '1', type: 'bug', title: 't', content: 'c', created: 'now' }]);
+  expect(insert).toHaveBeenCalledWith([
+    { id: '1', type: 'bug', title: 't', content: 'c', created: 'now', repo: 'owner/repo' },
+  ]);
+  await upsertRoadmap([{ id: '2', type: 'idea', title: 'i', content: 'c', created: 'now' }]);
+  expect(upsert).toHaveBeenCalledWith([
+    { id: '2', type: 'idea', title: 'i', content: 'c', created: 'now', repo: 'owner/repo' },
+  ], { onConflict: 'id' });
+});

--- a/tests/synthesize-tasks.test.ts
+++ b/tests/synthesize-tasks.test.ts
@@ -49,9 +49,10 @@ test('merges tasks and orders by date', async () => {
   const { synthesizeTasks } = await import('../src/cmds/synthesize-tasks.ts');
   await synthesizeTasks();
 
+  expect(fetchMock.mock.calls[0][0]).toContain('repo=eq.owner/repo');
   const updateBody = JSON.parse(fetchMock.mock.calls[1][1].body);
   const insertBody = JSON.parse(fetchMock.mock.calls[2][1].body);
-  const keys = ['title', 'type', 'content', 'priority', 'created', 'source'];
+  const keys = ['title', 'type', 'content', 'priority', 'created', 'source', 'repo'];
 
   expect(updateBody).toEqual([
     {
@@ -62,6 +63,7 @@ test('merges tasks and orders by date', async () => {
       priority: 1,
       created: new Date('2024-01-05').toISOString(),
       source: 'codex',
+      repo: TARGET_REPO,
     },
   ]);
   expect(Object.keys(updateBody[0])).toEqual(['id', ...keys]);
@@ -74,6 +76,7 @@ test('merges tasks and orders by date', async () => {
       priority: 2,
       created: new Date('2024-01-03').toISOString(),
       source: null,
+      repo: TARGET_REPO,
     },
     {
       title: 'Newer',
@@ -82,6 +85,7 @@ test('merges tasks and orders by date', async () => {
       priority: 3,
       created: new Date('2024-01-04').toISOString(),
       source: null,
+      repo: TARGET_REPO,
     },
   ]);
   const sortedKeys = (o: any) => Object.keys(o).sort();
@@ -118,8 +122,9 @@ test('filters out extra properties from existing tasks', async () => {
   const { synthesizeTasks } = await import('../src/cmds/synthesize-tasks.ts');
   await synthesizeTasks();
 
+  expect(fetchMock.mock.calls[0][0]).toContain('repo=eq.owner/repo');
   const body = JSON.parse(fetchMock.mock.calls[1][1].body);
-  const keys = ['id', 'title', 'type', 'content', 'priority', 'created', 'source'];
+  const keys = ['id', 'title', 'type', 'content', 'priority', 'created', 'source', 'repo'];
   expect(body[0]).toEqual({
     id: '1',
     title: 'Existing',
@@ -128,6 +133,7 @@ test('filters out extra properties from existing tasks', async () => {
     priority: 1,
     created: new Date('2024-01-05').toISOString(),
     source: 'codex',
+    repo: TARGET_REPO,
   });
   expect(Object.keys(body[0])).toEqual(keys);
 });


### PR DESCRIPTION
## Summary
- include TARGET_REPO when inserting/updating roadmap_items and filter reads by repo
- scope roadmap normalization, synthesis, and review commands to the current repo
- add tests verifying repo field usage in Supabase calls

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b88317b320832ab7fe0d9154980a8b