### PR TITLE
feat: include Supabase error details in sbRequest

### DIFF
--- a/dist/lib/supabase.js
+++ b/dist/lib/supabase.js
@@ -29,7 +29,25 @@ export async function sbRequest(path, init = {}) {
     };
     const res = await fetch(url, { ...init, headers });
     if (!res.ok) {
-        throw new Error(`Supabase error: ${res.status} ${res.statusText}`);
+        let bodyText = "";
+        try {
+            bodyText = await res.text();
+        }
+        catch {
+            // ignore
+        }
+        let detail = "";
+        try {
+            const data = JSON.parse(bodyText);
+            detail = [data.message, data.hint].filter(Boolean).join(" - ");
+            if (!detail) {
+                detail = bodyText.slice(0, 100);
+            }
+        }
+        catch {
+            detail = bodyText.slice(0, 100);
+        }
+        throw new Error(`Supabase error: ${res.status} ${res.statusText}${detail ? ` - ${detail}` : ""}`);
     }
     if (res.status === 204 || res.headers.get("Content-Length") === "0") {
         return undefined;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -37,16 +37,25 @@ export async function sbRequest(path: string, init: RequestInit = {}) {
   };
   const res = await fetch(url, { ...init, headers });
   if (!res.ok) {
-    let body = "";
+    let bodyText = "";
     try {
-      body = await res.text();
+      bodyText = await res.text();
     } catch {
       // ignore
     }
-    const snippet = body.slice(0, 100);
+    let detail = "";
+    try {
+      const data = JSON.parse(bodyText);
+      detail = [data.message, data.hint].filter(Boolean).join(" - ");
+      if (!detail) {
+        detail = bodyText.slice(0, 100);
+      }
+    } catch {
+      detail = bodyText.slice(0, 100);
+    }
     throw new Error(
       `Supabase error: ${res.status} ${res.statusText}${
-        snippet ? ` - ${snippet}` : ""
+        detail ? ` - ${detail}` : ""
       }`
     );
   }

--- a/tests/supabase.test.ts
+++ b/tests/supabase.test.ts
@@ -15,17 +15,17 @@ afterEach(() => {
   delete process.env.SUPABASE_SERVICE_ROLE_KEY;
 });
 
-test('sbRequest error includes response body', async () => {
-  const body = 'problem details';
+test('sbRequest error surfaces message and hint', async () => {
+  const body = { message: 'bad thing', hint: 'do better' };
   const fetchMock = vi.fn().mockResolvedValue({
     ok: false,
     status: 400,
     statusText: 'Bad Request',
-    text: async () => body,
+    text: async () => JSON.stringify(body),
   } as any);
   vi.stubGlobal('fetch', fetchMock);
 
   const { sbRequest } = await import('../src/lib/supabase.ts');
-  await expect(sbRequest('test')).rejects.toThrow(body);
+  await expect(sbRequest('test')).rejects.toThrow(`${body.message} - ${body.hint}`);
 });
 


### PR DESCRIPTION
## Summary
- handle Supabase error responses by parsing JSON body and including message and hint in thrown errors
- test that sbRequest surfaces full detail from a 400 response

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b883268d7c832ab9d520b5bb6d0533