### PR TITLE
fix: scope task synthesis to repo

### DIFF
--- a/tests/synthesize-tasks.test.ts
+++ b/tests/synthesize-tasks.test.ts
@@ -7,12 +7,14 @@ beforeEach(() => {
   vi.resetModules();
   process.env.SUPABASE_URL = SUPABASE_URL;
   process.env.SUPABASE_SERVICE_ROLE_KEY = SUPABASE_SERVICE_ROLE_KEY;
+  process.env.TARGET_REPO = 'owner/repo';
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
   delete process.env.SUPABASE_URL;
   delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  delete process.env.TARGET_REPO;
 });
 
 test('merges tasks and orders by date', async () => {
@@ -48,7 +50,7 @@ test('merges tasks and orders by date', async () => {
 
   const updateBody = JSON.parse(fetchMock.mock.calls[1][1].body);
   const insertBody = JSON.parse(fetchMock.mock.calls[2][1].body);
-  const keys = ['title', 'type', 'content', 'priority', 'created', 'source'];
+  const keys = ['title', 'type', 'content', 'priority', 'created', 'source', 'repo'];
 
   expect(updateBody).toEqual([
     {
@@ -59,6 +61,7 @@ test('merges tasks and orders by date', async () => {
       priority: 1,
       created: new Date('2024-01-05').toISOString(),
       source: 'codex',
+      repo: 'owner/repo',
     },
   ]);
   expect(Object.keys(updateBody[0])).toEqual(['id', ...keys]);
@@ -71,6 +74,7 @@ test('merges tasks and orders by date', async () => {
       priority: 2,
       created: new Date('2024-01-03').toISOString(),
       source: null,
+      repo: 'owner/repo',
     },
     {
       title: 'Newer',
@@ -79,6 +83,7 @@ test('merges tasks and orders by date', async () => {
       priority: 3,
       created: new Date('2024-01-04').toISOString(),
       source: null,
+      repo: 'owner/repo',
     },
   ]);
   const sortedKeys = (o: any) => Object.keys(o).sort();
@@ -116,7 +121,7 @@ test('filters out extra properties from existing tasks', async () => {
   await synthesizeTasks();
 
   const body = JSON.parse(fetchMock.mock.calls[1][1].body);
-  const keys = ['id', 'title', 'type', 'content', 'priority', 'created', 'source'];
+  const keys = ['id', 'title', 'type', 'content', 'priority', 'created', 'source', 'repo'];
   expect(body[0]).toEqual({
     id: '1',
     title: 'Existing',
@@ -125,6 +130,7 @@ test('filters out extra properties from existing tasks', async () => {
     priority: 1,
     created: new Date('2024-01-05').toISOString(),
     source: 'codex',
+    repo: 'owner/repo',
   });
   expect(Object.keys(body[0])).toEqual(keys);
 });


### PR DESCRIPTION
## Summary
- filter Supabase roadmap queries by repo
- include repo field on task upserts and deletes
- update tests for repo-scoped operations

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b89160fd44832ab079b57ff98dacdf