### PR TITLE
Use build logs for ingestion

### DIFF
--- a/dist/cmds/ingest-logs.js
+++ b/dist/cmds/ingest-logs.js
@@ -1,6 +1,6 @@
 // src/cmds/ingest-logs.ts
 import { acquireLock, releaseLock } from "../lib/lock.js";
-import { getLatestDeployment, getRuntimeLogs } from "../lib/vercel.js";
+import { getLatestDeployment, getBuildLogs } from "../lib/vercel.js";
 import { loadState, saveState, appendChangelog, appendDecision } from "../lib/state.js";
 import { summarizeLogToBug } from "../lib/prompts.js";
 import { insertRoadmap } from "../lib/roadmap.js";
@@ -20,7 +20,7 @@ function isInfraLog(e) {
     const path = (e.requestPath ?? "").toString();
     const INFRA_PATTERNS = [
         /ETIMEDOUT|ECONNRESET|ENOTFOUND|EAI_AGAIN/i,
-        /failed to fetch runtime-logs/i,
+        /failed to fetch (?:runtime|build)-logs/i,
         /Too Many Requests|rate limit/i,
         /https?:\/\/api\.vercel\.com/i,
         /Query exceeds 5-minute execution limit/i // exceeds Vercel's query time limit
@@ -52,15 +52,16 @@ export async function ingestLogs() {
         let raw = [];
         if (prevRowIds.length > 0) {
             const fromId = prevRowIds[prevRowIds.length - 1];
-            raw = (await getRuntimeLogs(dep.uid, { fromId, limit: 100, direction: "forward" }));
+            raw = (await getBuildLogs(dep.uid, { fromId, limit: 100, direction: "forward" }));
         }
         else {
             const now = Date.now();
             const from = new Date(now - 5 * 60 * 1000).toISOString();
             const until = new Date(now).toISOString();
-            raw = (await getRuntimeLogs(dep.uid, { from, until, limit: 100, direction: "forward" }));
+            raw = (await getBuildLogs(dep.uid, { from, until, limit: 100, direction: "forward" }));
         }
         const rawIds = raw.map(r => r?.id).filter(Boolean);
+        const nextRowIds = rawIds.length > 0 ? rawIds : prevRowIds;
         const prevIds = new Set(prevRowIds);
         const entries = raw
             .filter(r => r && (r.level === "error" || r.level === "warning"))
@@ -74,7 +75,10 @@ export async function ingestLogs() {
         }));
         if (entries.length === 0) {
             console.log("No relevant log entries.");
-            await saveState({ ...state, ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: rawIds } });
+            await saveState({
+                ...state,
+                ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: nextRowIds }
+            });
             return;
         }
         const appEntries = entries.filter(e => !isInfraLog(e));
@@ -91,7 +95,10 @@ export async function ingestLogs() {
                 created: new Date().toISOString()
             };
             await insertRoadmap([item]);
-            await saveState({ ...state, ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: rawIds } });
+            await saveState({
+                ...state,
+                ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: nextRowIds }
+            });
             await appendChangelog("Handled infra-only logs during ingestion.");
             await appendDecision("Routed infra-related logs to Supabase as ideas instead of bugs.");
             console.log("Infra-only logs detected; routed to Supabase as type=idea.");
@@ -99,7 +106,10 @@ export async function ingestLogs() {
         }
         if (appEntries.length === 0) {
             console.log("No application log entries to process.");
-            await saveState({ ...state, ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: rawIds } });
+            await saveState({
+                ...state,
+                ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: nextRowIds }
+            });
             await appendChangelog("Ingestion run found no application logs.");
             await appendDecision("No app logs to process from latest deployment.");
             return;
@@ -123,7 +133,7 @@ export async function ingestLogs() {
             if (!summary)
                 continue;
             const lines = summary.trim().split("\n");
-            const title = lines[0]?.replace(/^#+\s*/, "").trim() || "Runtime error from logs";
+            const title = lines[0]?.replace(/^#+\s*/, "").trim() || "Build error from logs";
             const content = lines.slice(1).join("\n").trim();
             items.push({
                 id: `BUG-${dep.uid.slice(0, 6)}-${Date.now()}`,
@@ -134,9 +144,12 @@ export async function ingestLogs() {
             });
         }
         await insertRoadmap(items);
-        await saveState({ ...state, ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: rawIds } });
-        await appendChangelog("Ingested runtime logs and inserted bugs into Supabase.");
-        await appendDecision("Processed runtime logs and updated state after ingestion.");
+        await saveState({
+            ...state,
+            ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: nextRowIds }
+        });
+        await appendChangelog("Ingested build logs and inserted bugs into Supabase.");
+        await appendDecision("Processed build logs and updated state after ingestion.");
         console.log("Ingest complete.");
     }
     finally {

--- a/dist/lib/vercel.js
+++ b/dist/lib/vercel.js
@@ -21,10 +21,10 @@ export async function getLatestDeployment() {
     });
     return data.deployments?.[0];
 }
-export async function getRuntimeLogs(deploymentId, opts = {}) {
+export async function getBuildLogs(deploymentId, opts = {}) {
     if (!ENV.VERCEL_PROJECT_ID)
         return [];
-    const url = new URL(`${API}/v1/projects/${ENV.VERCEL_PROJECT_ID}/deployments/${deploymentId}/runtime-logs`);
+    const url = new URL(`${API}/v6/deployments/${deploymentId}/build-logs`);
     if (ENV.VERCEL_TEAM_ID)
         url.searchParams.set("teamId", ENV.VERCEL_TEAM_ID);
     const { fromId, from, until, limit, direction } = opts;
@@ -49,7 +49,7 @@ export async function getRuntimeLogs(deploymentId, opts = {}) {
     }
     catch (err) {
         if (err.name === "AbortError") {
-            console.warn("Vercel runtime-logs request timed out");
+            console.warn("Vercel build-logs request timed out");
         }
         throw err;
     }
@@ -57,7 +57,7 @@ export async function getRuntimeLogs(deploymentId, opts = {}) {
         clearTimeout(t);
     }
     if (!res.ok)
-        throw new Error(`Vercel runtime-logs failed: ${res.status}`);
+        throw new Error(`Vercel build-logs failed: ${res.status}`);
     const text = await res.text();
     return text
         .split("\n")

--- a/src/cmds/ingest-logs.ts
+++ b/src/cmds/ingest-logs.ts
@@ -1,7 +1,7 @@
 // src/cmds/ingest-logs.ts
 
 import { acquireLock, releaseLock } from "../lib/lock.js";
-import { getLatestDeployment, getRuntimeLogs } from "../lib/vercel.js";
+import { getLatestDeployment, getBuildLogs } from "../lib/vercel.js";
 import { loadState, saveState, appendChangelog, appendDecision } from "../lib/state.js";
 import { summarizeLogToBug, type LogEntryForBug } from "../lib/prompts.js";
 import { insertRoadmap, type RoadmapItem } from "../lib/roadmap.js";
@@ -33,7 +33,7 @@ function isInfraLog(e: RawLog): boolean {
   const path = (e.requestPath ?? "").toString();
   const INFRA_PATTERNS = [
     /ETIMEDOUT|ECONNRESET|ENOTFOUND|EAI_AGAIN/i,
-    /failed to fetch runtime-logs/i,
+    /failed to fetch (?:runtime|build)-logs/i,
     /Too Many Requests|rate limit/i,
     /https?:\/\/api\.vercel\.com/i,
     /Query exceeds 5-minute execution limit/i // exceeds Vercel's query time limit
@@ -68,12 +68,12 @@ export async function ingestLogs(): Promise<void> {
     let raw: any[] = [];
     if (prevRowIds.length > 0) {
       const fromId = prevRowIds[prevRowIds.length - 1];
-      raw = (await getRuntimeLogs(dep.uid, { fromId, limit: 100, direction: "forward" })) as any[];
+      raw = (await getBuildLogs(dep.uid, { fromId, limit: 100, direction: "forward" })) as any[];
     } else {
       const now = Date.now();
       const from = new Date(now - 5 * 60 * 1000).toISOString();
       const until = new Date(now).toISOString();
-      raw = (await getRuntimeLogs(dep.uid, { from, until, limit: 100, direction: "forward" })) as any[];
+      raw = (await getBuildLogs(dep.uid, { from, until, limit: 100, direction: "forward" })) as any[];
     }
     const rawIds = raw.map(r => r?.id).filter(Boolean) as string[];
     const nextRowIds = rawIds.length > 0 ? rawIds : prevRowIds;
@@ -155,7 +155,7 @@ export async function ingestLogs(): Promise<void> {
       if (!summary) continue;
 
       const lines = summary.trim().split("\n");
-      const title = lines[0]?.replace(/^#+\s*/, "").trim() || "Runtime error from logs";
+      const title = lines[0]?.replace(/^#+\s*/, "").trim() || "Build error from logs";
       const content = lines.slice(1).join("\n").trim();
 
       items.push({
@@ -173,8 +173,8 @@ export async function ingestLogs(): Promise<void> {
       ...state,
       ingest: { lastDeploymentTimestamp: dep.createdAt, lastRowIds: nextRowIds }
     });
-    await appendChangelog("Ingested runtime logs and inserted bugs into Supabase.");
-    await appendDecision("Processed runtime logs and updated state after ingestion.");
+    await appendChangelog("Ingested build logs and inserted bugs into Supabase.");
+    await appendDecision("Processed build logs and updated state after ingestion.");
     console.log("Ingest complete.");
   } finally {
     await releaseLock();

--- a/src/lib/vercel.ts
+++ b/src/lib/vercel.ts
@@ -4,7 +4,7 @@ const API = "https://api.vercel.com";
 
 async function vfetch(path: string, params: Record<string, string | undefined> = {}) {
   const url = new URL(API + path);
-  for (const [k,v] of Object.entries(params)) if (v) url.searchParams.set(k, v);
+  for (const [k, v] of Object.entries(params)) if (v) url.searchParams.set(k, v);
   const res = await fetch(url, { headers: { Authorization: `Bearer ${ENV.VERCEL_TOKEN}` } });
   if (!res.ok) throw new Error(`Vercel ${path} failed: ${res.status}`);
   return res.json();
@@ -21,7 +21,7 @@ export async function getLatestDeployment() {
   return data.deployments?.[0];
 }
 
-export async function getRuntimeLogs(
+export async function getBuildLogs(
   deploymentId: string,
   opts: {
     fromId?: string;
@@ -29,11 +29,11 @@ export async function getRuntimeLogs(
     until?: string;
     limit?: number;
     direction?: string;
-  } = {}
+  } = {},
 ) {
   if (!ENV.VERCEL_PROJECT_ID) return [];
   const url = new URL(
-    `${API}/v1/projects/${ENV.VERCEL_PROJECT_ID}/deployments/${deploymentId}/runtime-logs`
+    `${API}/v6/deployments/${deploymentId}/build-logs`
   );
   if (ENV.VERCEL_TEAM_ID) url.searchParams.set("teamId", ENV.VERCEL_TEAM_ID);
   const { fromId, from, until, limit, direction } = opts;
@@ -53,13 +53,13 @@ export async function getRuntimeLogs(
     });
   } catch (err) {
     if ((err as any).name === "AbortError") {
-      console.warn("Vercel runtime-logs request timed out");
+      console.warn("Vercel build-logs request timed out");
     }
     throw err;
   } finally {
     clearTimeout(t);
   }
-  if (!res.ok) throw new Error(`Vercel runtime-logs failed: ${res.status}`);
+  if (!res.ok) throw new Error(`Vercel build-logs failed: ${res.status}`);
   const text = await res.text();
   return text
     .split("\n")
@@ -73,3 +73,4 @@ export async function getRuntimeLogs(
     })
     .filter(Boolean);
 }
+

--- a/tests/ingest-logs.test.ts
+++ b/tests/ingest-logs.test.ts
@@ -9,55 +9,55 @@ afterEach(() => {
 });
 
 test('ingestLogs only fetches new log entries on repeat runs', async () => {
-  vi.mock('../src/lib/lock.js', () => ({
-    acquireLock: vi.fn().mockResolvedValue(true),
-    releaseLock: vi.fn().mockResolvedValue(undefined),
-  }));
-  vi.mock('../src/lib/state.js', () => ({
-    loadState: vi.fn(),
-    saveState: vi.fn(),
-    appendChangelog: vi.fn(),
-    appendDecision: vi.fn(),
-  }));
-  vi.mock('../src/lib/vercel.js', () => ({
-    getLatestDeployment: vi.fn(),
-    getRuntimeLogs: vi.fn(),
-  }));
-  vi.mock('../src/lib/prompts.js', () => ({ summarizeLogToBug: vi.fn().mockResolvedValue('# t\ncontent') }));
-  vi.mock('../src/lib/roadmap.js', () => ({ insertRoadmap: vi.fn() }));
+    vi.mock('../src/lib/lock.js', () => ({
+      acquireLock: vi.fn().mockResolvedValue(true),
+      releaseLock: vi.fn().mockResolvedValue(undefined),
+    }));
+    vi.mock('../src/lib/state.js', () => ({
+      loadState: vi.fn(),
+      saveState: vi.fn(),
+      appendChangelog: vi.fn(),
+      appendDecision: vi.fn(),
+    }));
+    vi.mock('../src/lib/vercel.js', () => ({
+      getLatestDeployment: vi.fn(),
+      getBuildLogs: vi.fn(),
+    }));
+    vi.mock('../src/lib/prompts.js', () => ({ summarizeLogToBug: vi.fn().mockResolvedValue('# t\ncontent') }));
+    vi.mock('../src/lib/roadmap.js', () => ({ insertRoadmap: vi.fn() }));
 
-  const { ingestLogs } = await import('../src/cmds/ingest-logs.ts');
-  const { getLatestDeployment, getRuntimeLogs } = await import('../src/lib/vercel.js');
-  const { loadState, saveState } = await import('../src/lib/state.js');
-  const { insertRoadmap } = await import('../src/lib/roadmap.js');
+    const { ingestLogs } = await import('../src/cmds/ingest-logs.ts');
+    const { getLatestDeployment, getBuildLogs } = await import('../src/lib/vercel.js');
+    const { loadState, saveState } = await import('../src/lib/state.js');
+    const { insertRoadmap } = await import('../src/lib/roadmap.js');
 
-  loadState
-    .mockResolvedValueOnce({})
-    .mockResolvedValueOnce({ ingest: { lastDeploymentTimestamp: 1, lastRowIds: ['id1', 'id2'] } })
-    .mockResolvedValueOnce({ ingest: { lastDeploymentTimestamp: 1, lastRowIds: ['id2', 'id3'] } });
-  getLatestDeployment.mockResolvedValue({ uid: 'dep1', createdAt: 1 });
-  getRuntimeLogs
-    .mockResolvedValueOnce([
-      { id: 'id1', level: 'error', message: 'a' },
-      { id: 'id2', level: 'error', message: 'b' },
-    ])
-    .mockResolvedValueOnce([
-      { id: 'id2', level: 'error', message: 'b' },
-      { id: 'id3', level: 'error', message: 'c' },
-    ])
-    .mockResolvedValueOnce([]);
+    loadState
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ ingest: { lastDeploymentTimestamp: 1, lastRowIds: ['id1', 'id2'] } })
+      .mockResolvedValueOnce({ ingest: { lastDeploymentTimestamp: 1, lastRowIds: ['id2', 'id3'] } });
+    getLatestDeployment.mockResolvedValue({ uid: 'dep1', createdAt: 1 });
+    getBuildLogs
+      .mockResolvedValueOnce([
+        { id: 'id1', level: 'error', message: 'a' },
+        { id: 'id2', level: 'error', message: 'b' },
+      ])
+      .mockResolvedValueOnce([
+        { id: 'id2', level: 'error', message: 'b' },
+        { id: 'id3', level: 'error', message: 'c' },
+      ])
+      .mockResolvedValueOnce([]);
 
-  await ingestLogs();
-  await ingestLogs();
-  await ingestLogs();
+    await ingestLogs();
+    await ingestLogs();
+    await ingestLogs();
 
-  expect(getRuntimeLogs.mock.calls[1][1]).toEqual(
-    expect.objectContaining({ fromId: 'id2' })
-  );
-  expect(getRuntimeLogs.mock.calls[2][1]).toEqual(
-    expect.objectContaining({ fromId: 'id3' })
-  );
-  expect(insertRoadmap).toHaveBeenCalledTimes(2);
-  expect(saveState.mock.calls[1][0].ingest.lastRowIds).toEqual(['id2', 'id3']);
-  expect(saveState.mock.calls[2][0].ingest.lastRowIds).toEqual(['id2', 'id3']);
-});
+    expect(getBuildLogs.mock.calls[1][1]).toEqual(
+      expect.objectContaining({ fromId: 'id2' })
+    );
+    expect(getBuildLogs.mock.calls[2][1]).toEqual(
+      expect.objectContaining({ fromId: 'id3' })
+    );
+    expect(insertRoadmap).toHaveBeenCalledTimes(2);
+    expect(saveState.mock.calls[1][0].ingest.lastRowIds).toEqual(['id2', 'id3']);
+    expect(saveState.mock.calls[2][0].ingest.lastRowIds).toEqual(['id2', 'id3']);
+  });

--- a/tests/vercel.test.ts
+++ b/tests/vercel.test.ts
@@ -15,11 +15,11 @@ afterEach(() => {
   delete process.env.VERCEL_TEAM_ID;
 });
 
-test('getRuntimeLogs passes paging params', async () => {
-  const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => '' } as any);
-  vi.stubGlobal('fetch', fetchMock);
-  const { getRuntimeLogs } = await import('../src/lib/vercel.ts');
-  await getRuntimeLogs('dep1', { from: 'a', until: 'b', limit: 5, direction: 'forward' });
+  test('getBuildLogs passes paging params', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => '' } as any);
+    vi.stubGlobal('fetch', fetchMock);
+    const { getBuildLogs } = await import('../src/lib/vercel.ts');
+    await getBuildLogs('dep1', { from: 'a', until: 'b', limit: 5, direction: 'forward' });
   const url = fetchMock.mock.calls[0][0] as URL;
   expect(url.searchParams.get('from')).toBe('a');
   expect(url.searchParams.get('until')).toBe('b');
@@ -27,16 +27,16 @@ test('getRuntimeLogs passes paging params', async () => {
   expect(url.searchParams.get('direction')).toBe('forward');
 });
 
-test('getRuntimeLogs uses fromId when provided', async () => {
-  const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => '' } as any);
-  vi.stubGlobal('fetch', fetchMock);
-  const { getRuntimeLogs } = await import('../src/lib/vercel.ts');
-  await getRuntimeLogs('dep1', { fromId: '123' });
+  test('getBuildLogs uses fromId when provided', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => '' } as any);
+    vi.stubGlobal('fetch', fetchMock);
+    const { getBuildLogs } = await import('../src/lib/vercel.ts');
+    await getBuildLogs('dep1', { fromId: '123' });
   const url = fetchMock.mock.calls[0][0] as URL;
   expect(url.searchParams.get('from')).toBe('123');
 });
 
-test('getRuntimeLogs rejects on timeout', async () => {
+  test('getBuildLogs rejects on timeout', async () => {
   vi.useFakeTimers();
   vi.stubGlobal('fetch', vi.fn().mockImplementation((_url, opts) => {
     return new Promise((_, reject) => {
@@ -47,8 +47,8 @@ test('getRuntimeLogs rejects on timeout', async () => {
       });
     });
   }));
-  const { getRuntimeLogs } = await import('../src/lib/vercel.ts');
-  const p = expect(getRuntimeLogs('dep1')).rejects.toMatchObject({ name: 'AbortError' });
+    const { getBuildLogs } = await import('../src/lib/vercel.ts');
+    const p = expect(getBuildLogs('dep1')).rejects.toMatchObject({ name: 'AbortError' });
   await vi.advanceTimersByTimeAsync(31_000);
   await p;
 });


### PR DESCRIPTION
## Summary
- switch ingestion to pull build logs instead of runtime logs
- include build-log errors in infra filtering and summaries

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b89d10a240832a8c20b69eec84fd8b