### PR TITLE
Use deployment timestamp for initial build log fetch

### DIFF
--- a/dist/cmds/ingest-logs.js
+++ b/dist/cmds/ingest-logs.js
@@ -55,10 +55,8 @@ export async function ingestLogs() {
             raw = (await getBuildLogs(dep.uid, { fromId, limit: 100, direction: "forward" }));
         }
         else {
-            const now = Date.now();
-            const from = new Date(now - 5 * 60 * 1000).toISOString();
-            const until = new Date(now).toISOString();
-            raw = (await getBuildLogs(dep.uid, { from, until, limit: 100, direction: "forward" }));
+            const from = new Date(dep.createdAt).toISOString();
+            raw = (await getBuildLogs(dep.uid, { from, limit: 100, direction: "forward" }));
         }
         const rawIds = raw.map(r => r?.id).filter(Boolean);
         const nextRowIds = rawIds.length > 0 ? rawIds : prevRowIds;

--- a/src/cmds/ingest-logs.ts
+++ b/src/cmds/ingest-logs.ts
@@ -70,10 +70,8 @@ export async function ingestLogs(): Promise<void> {
       const fromId = prevRowIds[prevRowIds.length - 1];
       raw = (await getBuildLogs(dep.uid, { fromId, limit: 100, direction: "forward" })) as any[];
     } else {
-      const now = Date.now();
-      const from = new Date(now - 5 * 60 * 1000).toISOString();
-      const until = new Date(now).toISOString();
-      raw = (await getBuildLogs(dep.uid, { from, until, limit: 100, direction: "forward" })) as any[];
+      const from = new Date(dep.createdAt).toISOString();
+      raw = (await getBuildLogs(dep.uid, { from, limit: 100, direction: "forward" })) as any[];
     }
     const rawIds = raw.map(r => r?.id).filter(Boolean) as string[];
     const nextRowIds = rawIds.length > 0 ? rawIds : prevRowIds;

--- a/tests/ingest-logs.test.ts
+++ b/tests/ingest-logs.test.ts
@@ -51,6 +51,9 @@ test('ingestLogs only fetches new log entries on repeat runs', async () => {
     await ingestLogs();
     await ingestLogs();
 
+    expect(getBuildLogs.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ from: new Date(1).toISOString() })
+    );
     expect(getBuildLogs.mock.calls[1][1]).toEqual(
       expect.objectContaining({ fromId: 'id2' })
     );


### PR DESCRIPTION
## Summary
- pull build logs from deployment start when no previous IDs
- test initial ingestion uses deployment timestamp

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b8a4c3f930832abd52cf132dee1fb4