### PR TITLE
Handle missing Vercel build logs

### DIFF
--- a/dist/lib/vercel.js
+++ b/dist/lib/vercel.js
@@ -56,6 +56,8 @@ export async function getBuildLogs(deploymentId, opts = {}) {
     finally {
         clearTimeout(t);
     }
+    if (res.status === 404)
+        return [];
     if (!res.ok)
         throw new Error(`Vercel build-logs failed: ${res.status}`);
     const text = await res.text();

--- a/src/lib/vercel.ts
+++ b/src/lib/vercel.ts
@@ -59,6 +59,7 @@ export async function getBuildLogs(
   } finally {
     clearTimeout(t);
   }
+  if (res.status === 404) return [];
   if (!res.ok) throw new Error(`Vercel build-logs failed: ${res.status}`);
   const text = await res.text();
   return text

--- a/tests/vercel.test.ts
+++ b/tests/vercel.test.ts
@@ -52,3 +52,11 @@ afterEach(() => {
   await vi.advanceTimersByTimeAsync(31_000);
   await p;
 });
+
+test('getBuildLogs returns empty array on 404', async () => {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 404, text: async () => '' } as any);
+  vi.stubGlobal('fetch', fetchMock);
+  const { getBuildLogs } = await import('../src/lib/vercel.ts');
+  const res = await getBuildLogs('dep1');
+  expect(res).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- Avoid failing on Vercel build log 404 responses by treating them as no logs
- Cover the missing-log scenario with a unit test

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b8a679ceac832a91591ab99980bc3c