### PR TITLE
fix: treat stderr build logs as errors

### DIFF
--- a/dist/cmds/ingest-logs.js
+++ b/dist/cmds/ingest-logs.js
@@ -62,15 +62,24 @@ export async function ingestLogs() {
         const nextRowIds = rawIds.length > 0 ? rawIds : prevRowIds;
         const prevIds = new Set(prevRowIds);
         const entries = raw
-            .filter(r => r && (r.level === "error" || r.level === "warning"))
+            .filter(r => {
+            if (!r)
+                return false;
+            const lvl = (r.level ?? r.type ?? "").toString().toLowerCase();
+            return lvl === "error" || lvl === "warning" || lvl === "stderr";
+        })
             .filter(r => !prevIds.has(r.id))
-            .map(r => ({
-            id: r.id,
-            level: r.level,
-            message: r.message ?? r.text ?? "",
-            requestPath: r.requestPath ?? "",
-            timestamp: r.timestamp ?? ""
-        }));
+            .map(r => {
+            const lvl = (r.level ?? r.type ?? "").toString().toLowerCase();
+            const normalizedLevel = lvl === "stderr" ? "error" : lvl;
+            return {
+                id: r.id,
+                level: normalizedLevel,
+                message: r.message ?? r.text ?? "",
+                requestPath: r.requestPath ?? "",
+                timestamp: r.timestamp ?? ""
+            };
+        });
         if (entries.length === 0) {
             console.log("No relevant log entries.");
             await saveState({

--- a/tests/ingest-logs.test.ts
+++ b/tests/ingest-logs.test.ts
@@ -38,12 +38,12 @@ test('ingestLogs only fetches new log entries on repeat runs', async () => {
     getLatestDeployment.mockResolvedValue({ uid: 'dep1', createdAt: 1 });
     getBuildLogs
       .mockResolvedValueOnce([
-        { id: 'id1', level: 'error', message: 'a' },
-        { id: 'id2', level: 'error', message: 'b' },
+        { id: 'id1', type: 'stderr', text: 'a' },
+        { id: 'id2', type: 'stderr', text: 'b' },
       ])
       .mockResolvedValueOnce([
-        { id: 'id2', level: 'error', message: 'b' },
-        { id: 'id3', level: 'error', message: 'c' },
+        { id: 'id2', type: 'stderr', text: 'b' },
+        { id: 'id3', type: 'stderr', text: 'c' },
       ])
       .mockResolvedValueOnce([]);
 


### PR DESCRIPTION
## Summary
- handle Vercel build logs that provide `type: 'stderr'` so ingestion no longer misses them
- adjust ingest logs test to cover stderr-only log entries

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b8b5209a90832ab6a934f35478d26e