### PR TITLE
fix: treat stderr build logs as errors

### DIFF
--- a/src/cmds/ingest-logs.ts
+++ b/src/cmds/ingest-logs.ts
@@ -79,16 +79,18 @@ export async function ingestLogs(): Promise<void> {
     const entries: RawLog[] = raw
       .filter(r => {
         if (!r) return false;
-        const lvl = (r.level ?? r.type ?? "").toString().toLowerCase();
-        return lvl === "error" || lvl === "warning" || lvl === "stderr";
+        const level = (r.level ?? "").toString().toLowerCase();
+        const type = (r.type ?? "").toString().toLowerCase();
+        return level === "error" || level === "warning" || type === "stderr";
       })
       .filter(r => !prevIds.has(r.id))
       .map(r => {
-        const lvl = (r.level ?? r.type ?? "").toString().toLowerCase();
-        const normalizedLevel = lvl === "stderr" ? "error" : lvl;
+        const level = (r.level ?? "").toString().toLowerCase();
+        const type = (r.type ?? "").toString().toLowerCase();
+        const lvl = type === "stderr" ? "error" : level || type;
         return {
           id: r.id,
-          level: normalizedLevel,
+          level: lvl,
           message: r.message ?? r.text ?? "",
           requestPath: r.requestPath ?? "",
           timestamp: r.timestamp ?? ""

--- a/tests/ingest-logs.test.ts
+++ b/tests/ingest-logs.test.ts
@@ -38,12 +38,12 @@ test('ingestLogs only fetches new log entries on repeat runs', async () => {
     getLatestDeployment.mockResolvedValue({ uid: 'dep1', createdAt: 1 });
     getBuildLogs
       .mockResolvedValueOnce([
-        { id: 'id1', type: 'stderr', text: 'a' },
-        { id: 'id2', type: 'stderr', text: 'b' },
+        { id: 'id1', type: 'stderr', level: 'info', text: 'a' },
+        { id: 'id2', type: 'stderr', level: 'info', text: 'b' },
       ])
       .mockResolvedValueOnce([
-        { id: 'id2', type: 'stderr', text: 'b' },
-        { id: 'id3', type: 'stderr', text: 'c' },
+        { id: 'id2', type: 'stderr', level: 'info', text: 'b' },
+        { id: 'id3', type: 'stderr', level: 'info', text: 'c' },
       ])
       .mockResolvedValueOnce([]);
 


### PR DESCRIPTION
## Summary
- handle stderr log entries even when level isn't an error
- extend ingest-logs test to cover stderr entries with non-error level

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b8b6f3e020832aa5126fbf9199ec04