### PR TITLE
feat: stream vercel build logs for ingestion

### DIFF
--- a/tests/ingest-logs.test.ts
+++ b/tests/ingest-logs.test.ts
@@ -37,15 +37,15 @@ test('ingestLogs only fetches new log entries on repeat runs', async () => {
       .mockResolvedValueOnce({ ingest: { lastDeploymentTimestamp: 1, lastRowIds: ['id2', 'id3'] } });
     getLatestDeployment.mockResolvedValue({ uid: 'dep1', createdAt: 1 });
     getBuildLogs
-      .mockResolvedValueOnce([
-        { id: 'id1', type: 'stderr', level: 'info', text: 'a' },
-        { id: 'id2', type: 'stderr', level: 'info', text: 'b' },
-      ])
-      .mockResolvedValueOnce([
-        { id: 'id2', type: 'stderr', level: 'info', text: 'b' },
-        { id: 'id3', type: 'stderr', level: 'info', text: 'c' },
-      ])
-      .mockResolvedValueOnce([]);
+      .mockImplementationOnce(async function* () {
+        yield { id: 'id1', type: 'stderr', level: 'info', text: 'a' };
+        yield { id: 'id2', type: 'stderr', level: 'info', text: 'b' };
+      })
+      .mockImplementationOnce(async function* () {
+        yield { id: 'id2', type: 'stderr', level: 'info', text: 'b' };
+        yield { id: 'id3', type: 'stderr', level: 'info', text: 'c' };
+      })
+      .mockImplementationOnce(async function* () {});
 
     await ingestLogs();
     await ingestLogs();

--- a/tests/vercel.test.ts
+++ b/tests/vercel.test.ts
@@ -16,47 +16,51 @@ afterEach(() => {
 });
 
   test('getBuildLogs passes paging params', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => '' } as any);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, body: undefined } as any);
     vi.stubGlobal('fetch', fetchMock);
     const { getBuildLogs } = await import('../src/lib/vercel.ts');
-    await getBuildLogs('dep1', { from: 'a', until: 'b', limit: 5, direction: 'forward' });
-  const url = fetchMock.mock.calls[0][0] as URL;
-  expect(url.searchParams.get('from')).toBe('a');
-  expect(url.searchParams.get('until')).toBe('b');
-  expect(url.searchParams.get('limit')).toBe('5');
-  expect(url.searchParams.get('direction')).toBe('forward');
-});
+    const gen = getBuildLogs('dep1', { from: 'a', until: 'b', limit: 5, direction: 'forward' });
+    await gen?.next();
+    const url = fetchMock.mock.calls[0][0] as URL;
+    expect(url.searchParams.get('from')).toBe('a');
+    expect(url.searchParams.get('until')).toBe('b');
+    expect(url.searchParams.get('limit')).toBe('5');
+    expect(url.searchParams.get('direction')).toBe('forward');
+  });
 
   test('getBuildLogs uses fromId when provided', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => '' } as any);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, body: undefined } as any);
     vi.stubGlobal('fetch', fetchMock);
     const { getBuildLogs } = await import('../src/lib/vercel.ts');
-    await getBuildLogs('dep1', { fromId: '123' });
-  const url = fetchMock.mock.calls[0][0] as URL;
-  expect(url.searchParams.get('from')).toBe('123');
-});
+    const gen = getBuildLogs('dep1', { fromId: '123' });
+    await gen?.next();
+    const url = fetchMock.mock.calls[0][0] as URL;
+    expect(url.searchParams.get('from')).toBe('123');
+  });
 
   test('getBuildLogs rejects on timeout', async () => {
-  vi.useFakeTimers();
-  vi.stubGlobal('fetch', vi.fn().mockImplementation((_url, opts) => {
-    return new Promise((_, reject) => {
-      opts?.signal?.addEventListener('abort', () => {
-        const err = new Error('aborted');
-        (err as any).name = 'AbortError';
-        reject(err);
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((_url, opts) => {
+      return new Promise((_, reject) => {
+        opts?.signal?.addEventListener('abort', () => {
+          const err = new Error('aborted');
+          (err as any).name = 'AbortError';
+          reject(err);
+        });
       });
-    });
-  }));
+    }));
     const { getBuildLogs } = await import('../src/lib/vercel.ts');
-    const p = expect(getBuildLogs('dep1')).rejects.toMatchObject({ name: 'AbortError' });
-  await vi.advanceTimersByTimeAsync(31_000);
-  await p;
-});
+    const gen = getBuildLogs('dep1');
+    const p = expect(gen?.next()).rejects.toMatchObject({ name: 'AbortError' });
+    await vi.advanceTimersByTimeAsync(181_000);
+    await p;
+  });
 
-test('getBuildLogs returns empty array on 404', async () => {
-  const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 404, text: async () => '' } as any);
+test('getBuildLogs yields nothing on 404', async () => {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 404, body: undefined } as any);
   vi.stubGlobal('fetch', fetchMock);
   const { getBuildLogs } = await import('../src/lib/vercel.ts');
-  const res = await getBuildLogs('dep1');
+  const res: any[] = [];
+  for await (const r of getBuildLogs('dep1') || []) res.push(r);
   expect(res).toEqual([]);
 });


### PR DESCRIPTION
## Summary
- refactor `getBuildLogs` to stream Vercel logs and extend timeout
- update `ingestLogs` to consume streaming logs and summarize build errors
- adjust tests for streaming log retrieval

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ba0990cfec832aaaed5b54a36d036a