### PR TITLE
feat: validate repo slug and support separate owner

### DIFF
--- a/dist/lib/env.js
+++ b/dist/lib/env.js
@@ -1,8 +1,15 @@
 // src/lib/env.ts
+const owner = process.env.TARGET_OWNER || "";
+const repoInput = process.env.TARGET_REPO || "";
+const targetRepo = repoInput.includes("/")
+    ? repoInput
+    : owner && repoInput
+        ? `${owner}/${repoInput}`
+        : repoInput;
 export const ENV = {
     GH_USERNAME: process.env.GH_USERNAME || "ai-dev-agent",
     PAT_TOKEN: process.env.PAT_TOKEN || "",
-    TARGET_REPO: process.env.TARGET_REPO || "",
+    TARGET_REPO: targetRepo,
     TARGET_DIR: process.env.TARGET_DIR || "",
     VERCEL_PROJECT_ID: process.env.VERCEL_PROJECT_ID || "",
     VERCEL_TEAM_ID: process.env.VERCEL_TEAM_ID || "",

--- a/dist/lib/github.js
+++ b/dist/lib/github.js
@@ -8,10 +8,11 @@ function formatMessage(msg) {
     return msg.body ? `${msg.title}\n\n${msg.body}` : msg.title;
 }
 export function parseRepo(s) {
-    const [owner, repo] = s.split("/");
-    if (!owner || !repo)
+    const parts = s.split("/");
+    if (parts.length !== 2 || !parts[0] || !parts[1]) {
         throw new Error(`Invalid TARGET_REPO: ${s}`);
-    return { owner, repo };
+    }
+    return { owner: parts[0], repo: parts[1] };
 }
 function b64(s) {
     return Buffer.from(s, "utf8").toString("base64");

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,8 +1,16 @@
 // src/lib/env.ts
+const owner = process.env.TARGET_OWNER || "";
+const repoInput = process.env.TARGET_REPO || "";
+const targetRepo = repoInput.includes("/")
+  ? repoInput
+  : owner && repoInput
+    ? `${owner}/${repoInput}`
+    : repoInput;
+
 export const ENV = {
   GH_USERNAME: process.env.GH_USERNAME || "ai-dev-agent",
   PAT_TOKEN: process.env.PAT_TOKEN || "",
-  TARGET_REPO: process.env.TARGET_REPO || "",
+  TARGET_REPO: targetRepo,
   TARGET_DIR: process.env.TARGET_DIR || "",
   VERCEL_PROJECT_ID: process.env.VERCEL_PROJECT_ID || "",
   VERCEL_TEAM_ID: process.env.VERCEL_TEAM_ID || "",

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -13,9 +13,11 @@ function formatMessage(msg: CommitMessage): string {
 }
 
 export function parseRepo(s: string): RepoRef {
-  const [owner, repo] = s.split("/");
-  if (!owner || !repo) throw new Error(`Invalid TARGET_REPO: ${s}`);
-  return { owner, repo };
+  const parts = s.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error(`Invalid TARGET_REPO: ${s}`);
+  }
+  return { owner: parts[0], repo: parts[1] };
 }
 
 function b64(s: string) {

--- a/tests/parse-repo.test.ts
+++ b/tests/parse-repo.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'vitest';
+import { parseRepo } from '../src/lib/github';
+
+test('parseRepo rejects missing slash', () => {
+  expect(() => parseRepo('foo')).toThrow('Invalid TARGET_REPO: foo');
+});
+
+test('parseRepo rejects extra segments', () => {
+  expect(() => parseRepo('a/b/c')).toThrow('Invalid TARGET_REPO: a/b/c');
+});
+
+test('parseRepo splits owner and repo', () => {
+  expect(parseRepo('o/r')).toEqual({ owner: 'o', repo: 'r' });
+});


### PR DESCRIPTION
## Summary
- derive TARGET_REPO from separate TARGET_OWNER/TARGET_REPO vars when needed
- harden parseRepo to require a single owner/repo pair
- add unit tests for invalid repository strings

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb05cb2794832a99fdca04f77c74e3