### PR TITLE
feat: split target repo env

### DIFF
--- a/dist/cmds/implement.js
+++ b/dist/cmds/implement.js
@@ -10,7 +10,7 @@ export async function implementTopTask() {
         return;
     }
     try {
-        requireEnv(['TARGET_REPO']);
+        requireEnv(['TARGET_OWNER', 'TARGET_REPO']);
         const { supabase } = await import("../lib/supabase.js");
         // Load vision for context
         const vision = (await readFile("roadmap/vision.md")) || "";

--- a/dist/cmds/ingest-logs.js
+++ b/dist/cmds/ingest-logs.js
@@ -4,6 +4,7 @@ import { getLatestDeployment, getBuildLogs } from "../lib/vercel.js";
 import { loadState, saveState, appendChangelog, appendDecision } from "../lib/state.js";
 import { summarizeLogToBug } from "../lib/prompts.js";
 import { insertRoadmap } from "../lib/roadmap.js";
+import { requireEnv } from "../lib/env.js";
 function getLogSignature(message) {
     return message
         .replace(/\[\w+\]/g, "")
@@ -37,6 +38,7 @@ export async function ingestLogs() {
         return;
     }
     try {
+        requireEnv(["TARGET_OWNER", "TARGET_REPO"]);
         const state = await loadState();
         const dep = await getLatestDeployment();
         if (!dep) {

--- a/dist/cmds/normalize-roadmap.js
+++ b/dist/cmds/normalize-roadmap.js
@@ -1,6 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
 import { acquireLock, releaseLock } from "../lib/lock.js";
-import { ENV } from "../lib/env.js";
+import { ENV, requireEnv } from "../lib/env.js";
 import yaml from "js-yaml";
 function normTitle(t = "") {
     return t.toLowerCase().replace(/\s+/g, " ").replace(/[`"'*]/g, "").trim();
@@ -24,6 +24,7 @@ export async function normalizeRoadmap() {
         return;
     }
     try {
+        requireEnv(["TARGET_OWNER", "TARGET_REPO"]);
         const supabase = createClient(ENV.SUPABASE_URL, ENV.SUPABASE_SERVICE_ROLE_KEY);
         const { data, error } = await supabase
             .from("roadmap_items")

--- a/dist/cmds/review-repo.js
+++ b/dist/cmds/review-repo.js
@@ -1,5 +1,5 @@
 import { acquireLock, releaseLock } from "../lib/lock.js";
-import { parseRepo, gh } from "../lib/github.js";
+import { gh } from "../lib/github.js";
 import { reviewToIdeas, reviewToSummary } from "../lib/prompts.js";
 import { loadState, saveState, appendChangelog, appendDecision } from "../lib/state.js";
 import { requireEnv, ENV } from "../lib/env.js";
@@ -12,7 +12,7 @@ export async function reviewRepo() {
         return;
     }
     try {
-        requireEnv(["TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+        requireEnv(["TARGET_OWNER", "TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
         async function fetchRoadmap(type) {
             const data = (await sbRequest(`roadmap_items?select=content&type=eq.${type}`));
             return data ? data.map((r) => r.content).join("\n") : "";
@@ -20,8 +20,7 @@ export async function reviewRepo() {
         const roadmapTypes = ["vision", "task", "bugs", "done", "new"];
         const [vision, tasks, bugs, done, ideas] = await Promise.all(roadmapTypes.map(fetchRoadmap));
         const state = await loadState();
-        const { owner, repo } = parseRepo(ENV.TARGET_REPO);
-        const commitsResp = await gh.rest.repos.listCommits({ owner, repo, per_page: 10 });
+        const commitsResp = await gh.rest.repos.listCommits({ owner: ENV.OWNER, repo: ENV.REPO, per_page: 10 });
         const commitsData = [];
         for (const c of commitsResp.data) {
             if (c.sha === state.lastReviewedSha)

--- a/dist/cmds/synthesize-tasks.js
+++ b/dist/cmds/synthesize-tasks.js
@@ -24,7 +24,7 @@ export async function synthesizeTasks() {
         return;
     }
     try {
-        requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+        requireEnv(["TARGET_OWNER", "TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
         const vision = (await readFile("roadmap/vision.md")) || "";
         const rows = (await sbRequest(`roadmap_items?select=*`)).map((r) => ({
             ...r,

--- a/dist/lib/env.js
+++ b/dist/lib/env.js
@@ -2,7 +2,8 @@
 export const ENV = {
     GH_USERNAME: process.env.GH_USERNAME || "ai-dev-agent",
     PAT_TOKEN: process.env.PAT_TOKEN || "",
-    TARGET_REPO: process.env.TARGET_REPO || "",
+    OWNER: process.env.TARGET_OWNER || "",
+    REPO: process.env.TARGET_REPO || "",
     TARGET_DIR: process.env.TARGET_DIR || "",
     VERCEL_PROJECT_ID: process.env.VERCEL_PROJECT_ID || "",
     VERCEL_TEAM_ID: process.env.VERCEL_TEAM_ID || "",
@@ -16,6 +17,7 @@ export const ENV = {
     BRANCH: process.env.GITHUB_REF_NAME || process.env.GITHUB_HEAD_REF || "",
     ALLOW_PATHS: (process.env.ALLOW_PATHS || "").split(",").map(s => s.trim()).filter(Boolean),
 };
+export const TARGET_REPO_SLUG = `${ENV.OWNER}/${ENV.REPO}`;
 // Call this inside commands to assert only what they need.
 export function requireEnv(names) {
     for (const n of names) {

--- a/dist/lib/github.js
+++ b/dist/lib/github.js
@@ -10,7 +10,7 @@ function formatMessage(msg) {
 export function parseRepo(s) {
     const [owner, repo] = s.split("/");
     if (!owner || !repo)
-        throw new Error(`Invalid TARGET_REPO: ${s}`);
+        throw new Error(`Invalid repo: ${s}`);
     return { owner, repo };
 }
 function b64(s) {
@@ -33,12 +33,12 @@ async function getFile(owner, repo, path, ref) {
     }
 }
 export async function getDefaultBranch() {
-    const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+    const { OWNER: owner, REPO: repo } = ENV;
     const { data } = await gh.rest.repos.get({ owner, repo });
     return data.default_branch;
 }
 export async function ensureBranch(branch, baseBranch) {
-    const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+    const { OWNER: owner, REPO: repo } = ENV;
     const ref = `heads/${branch}`;
     try {
         await gh.rest.git.getRef({ owner, repo, ref });
@@ -70,12 +70,12 @@ export function resolveRepoPath(p) {
     return joined.replace(/^\/+/, "");
 }
 export async function readFile(path) {
-    const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+    const { OWNER: owner, REPO: repo } = ENV;
     const got = await getFile(owner, repo, path);
     return got.content;
 }
 export async function upsertFile(path, updater, message, opts) {
-    const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+    const { OWNER: owner, REPO: repo } = ENV;
     const safePath = resolveRepoPath(path);
     const ref = opts?.branch;
     if (ENV.DRY_RUN) {
@@ -99,7 +99,7 @@ export async function upsertFile(path, updater, message, opts) {
     });
 }
 export async function commitMany(files, message, opts) {
-    const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+    const { OWNER: owner, REPO: repo } = ENV;
     const ref = opts?.branch;
     const msg = formatMessage(message);
     if (ENV.DRY_RUN) {

--- a/dist/orchestrator.js
+++ b/dist/orchestrator.js
@@ -3,8 +3,9 @@ import { reviewRepo } from "./cmds/review-repo.js";
 import { implementTopTask } from "./cmds/implement.js";
 import { loadState } from "./lib/state.js";
 import { getLatestDeployment } from "./lib/vercel.js";
-import { gh, parseRepo } from "./lib/github.js";
-import { ENV } from "./lib/env.js";
+import { gh } from "./lib/github.js";
+import { ENV, requireEnv } from "./lib/env.js";
+requireEnv(["TARGET_OWNER", "TARGET_REPO"]);
 async function shouldIngest(state) {
     try {
         const dep = await getLatestDeployment();
@@ -18,10 +19,9 @@ async function shouldIngest(state) {
 }
 async function shouldReview(state) {
     try {
-        if (!ENV.TARGET_REPO)
+        if (!ENV.OWNER || !ENV.REPO)
             return false;
-        const { owner, repo } = parseRepo(ENV.TARGET_REPO);
-        const resp = await gh.rest.repos.listCommits({ owner, repo, per_page: 1 });
+        const resp = await gh.rest.repos.listCommits({ owner: ENV.OWNER, repo: ENV.REPO, per_page: 1 });
         const latest = resp.data[0]?.sha;
         return !!latest && latest !== state.lastReviewedSha;
     }

--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -18,7 +18,7 @@ type RoadmapItem = {
 export async function implementTopTask() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
-    requireEnv(['TARGET_REPO']);
+    requireEnv(['TARGET_OWNER', 'TARGET_REPO']);
     const { supabase } = await import("../lib/supabase.js");
     // Load vision for context
     const vision = (await readFile("roadmap/vision.md")) || "";

--- a/src/cmds/ingest-logs.ts
+++ b/src/cmds/ingest-logs.ts
@@ -5,6 +5,7 @@ import { getLatestDeployment, getBuildLogs } from "../lib/vercel.js";
 import { loadState, saveState, appendChangelog, appendDecision } from "../lib/state.js";
 import { summarizeLogToBug, type LogEntryForBug } from "../lib/prompts.js";
 import { insertRoadmap, type RoadmapItem } from "../lib/roadmap.js";
+import { requireEnv } from "../lib/env.js";
 
 type RawLog = {
   id?: string;
@@ -50,6 +51,7 @@ export async function ingestLogs(): Promise<void> {
   }
 
   try {
+    requireEnv(["TARGET_OWNER", "TARGET_REPO"]);
     const state = await loadState();
     const dep = await getLatestDeployment();
 

--- a/src/cmds/normalize-roadmap.ts
+++ b/src/cmds/normalize-roadmap.ts
@@ -1,7 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import type { Task } from "../lib/types.js";
-import { ENV } from "../lib/env.js";
+import { ENV, requireEnv } from "../lib/env.js";
 import yaml from "js-yaml";
 
 function normTitle(t = "") {
@@ -23,6 +23,7 @@ export function compareTasks(a: Task, b: Task) {
 export async function normalizeRoadmap() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
+    requireEnv(["TARGET_OWNER", "TARGET_REPO"]);
     const supabase = createClient(ENV.SUPABASE_URL, ENV.SUPABASE_SERVICE_ROLE_KEY);
     const { data, error } = await supabase
       .from("roadmap_items")

--- a/src/cmds/synthesize-tasks.ts
+++ b/src/cmds/synthesize-tasks.ts
@@ -24,7 +24,7 @@ export function compareTasks(a: Task, b: Task) {
 export async function synthesizeTasks() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
-    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+    requireEnv(["TARGET_OWNER", "TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
 
     const vision = (await readFile("roadmap/vision.md")) || "";
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -2,7 +2,8 @@
 export const ENV = {
   GH_USERNAME: process.env.GH_USERNAME || "ai-dev-agent",
   PAT_TOKEN: process.env.PAT_TOKEN || "",
-  TARGET_REPO: process.env.TARGET_REPO || "",
+  OWNER: process.env.TARGET_OWNER || "",
+  REPO: process.env.TARGET_REPO || "",
   TARGET_DIR: process.env.TARGET_DIR || "",
   VERCEL_PROJECT_ID: process.env.VERCEL_PROJECT_ID || "",
   VERCEL_TEAM_ID: process.env.VERCEL_TEAM_ID || "",
@@ -16,6 +17,8 @@ export const ENV = {
   BRANCH: process.env.GITHUB_REF_NAME || process.env.GITHUB_HEAD_REF || "",
   ALLOW_PATHS: (process.env.ALLOW_PATHS || "").split(",").map(s => s.trim()).filter(Boolean),
 };
+
+export const TARGET_REPO_SLUG = `${ENV.OWNER}/${ENV.REPO}`;
 
 // Call this inside commands to assert only what they need.
 export function requireEnv(names: string[]) {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -14,7 +14,7 @@ function formatMessage(msg: CommitMessage): string {
 
 export function parseRepo(s: string): RepoRef {
   const [owner, repo] = s.split("/");
-  if (!owner || !repo) throw new Error(`Invalid TARGET_REPO: ${s}`);
+  if (!owner || !repo) throw new Error(`Invalid repo: ${s}`);
   return { owner, repo };
 }
 
@@ -37,13 +37,13 @@ async function getFile(owner: string, repo: string, path: string, ref?: string) 
 }
 
 export async function getDefaultBranch(): Promise<string> {
-  const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+  const { OWNER: owner, REPO: repo } = ENV;
   const { data } = await gh.rest.repos.get({ owner, repo });
   return data.default_branch;
 }
 
 export async function ensureBranch(branch: string, baseBranch?: string): Promise<void> {
-  const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+  const { OWNER: owner, REPO: repo } = ENV;
   const ref = `heads/${branch}`;
   try {
     await gh.rest.git.getRef({ owner, repo, ref });
@@ -74,7 +74,7 @@ export function resolveRepoPath(p: string): string {
 }
 
 export async function readFile(path: string): Promise<string | undefined> {
-  const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+  const { OWNER: owner, REPO: repo } = ENV;
   const got = await getFile(owner, repo, path);
   return got.content;
 }
@@ -85,7 +85,7 @@ export async function upsertFile(
   message: CommitMessage,
   opts?: { branch?: string }
 ) {
-  const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+  const { OWNER: owner, REPO: repo } = ENV;
   const safePath = resolveRepoPath(path);
   const ref = opts?.branch;
   if (ENV.DRY_RUN) {
@@ -114,7 +114,7 @@ export async function commitMany(
   message: CommitMessage,
   opts?: { branch?: string }
 ) {
-  const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+  const { OWNER: owner, REPO: repo } = ENV;
   const ref = opts?.branch;
   const msg = formatMessage(message);
   if (ENV.DRY_RUN) {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -3,8 +3,10 @@ import { reviewRepo } from "./cmds/review-repo.js";
 import { implementTopTask } from "./cmds/implement.js";
 import { loadState, type AgentState } from "./lib/state.js";
 import { getLatestDeployment } from "./lib/vercel.js";
-import { gh, parseRepo } from "./lib/github.js";
-import { ENV } from "./lib/env.js";
+import { gh } from "./lib/github.js";
+import { ENV, requireEnv } from "./lib/env.js";
+
+requireEnv(["TARGET_OWNER", "TARGET_REPO"]);
 
 async function shouldIngest(state: AgentState): Promise<boolean> {
   try {
@@ -18,9 +20,8 @@ async function shouldIngest(state: AgentState): Promise<boolean> {
 
 async function shouldReview(state: AgentState): Promise<boolean> {
   try {
-    if (!ENV.TARGET_REPO) return false;
-    const { owner, repo } = parseRepo(ENV.TARGET_REPO);
-    const resp = await gh.rest.repos.listCommits({ owner, repo, per_page: 1 });
+    if (!ENV.OWNER || !ENV.REPO) return false;
+    const resp = await gh.rest.repos.listCommits({ owner: ENV.OWNER, repo: ENV.REPO, per_page: 1 });
     const latest = resp.data[0]?.sha;
     return !!latest && latest !== state.lastReviewedSha;
   } catch {

--- a/tests/implement.test.ts
+++ b/tests/implement.test.ts
@@ -2,18 +2,28 @@ import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 
 beforeEach(() => {
   vi.resetModules();
+  delete process.env.TARGET_OWNER;
   delete process.env.TARGET_REPO;
 });
 
 afterEach(() => {
-  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  delete process.env.TARGET_OWNER;
+  delete process.env.TARGET_REPO;
+});
+
+vi.mock('../src/lib/lock.js', () => ({
+  acquireLock: vi.fn().mockResolvedValue(true),
+  releaseLock: vi.fn().mockResolvedValue(undefined),
+}));
+
+test('implementTopTask throws when TARGET_OWNER missing', async () => {
+  const { implementTopTask } = await import('../src/cmds/implement.ts');
+  await expect(implementTopTask()).rejects.toThrow('Missing env: TARGET_OWNER');
 });
 
 test('implementTopTask throws when TARGET_REPO missing', async () => {
-  vi.mock('../src/lib/lock.js', () => ({
-    acquireLock: vi.fn().mockResolvedValue(true),
-    releaseLock: vi.fn().mockResolvedValue(undefined),
-  }));
+  process.env.TARGET_OWNER = 'o';
   const { implementTopTask } = await import('../src/cmds/implement.ts');
   await expect(implementTopTask()).rejects.toThrow('Missing env: TARGET_REPO');
 });

--- a/tests/ingest-logs.test.ts
+++ b/tests/ingest-logs.test.ts
@@ -6,9 +6,13 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  delete process.env.TARGET_OWNER;
+  delete process.env.TARGET_REPO;
 });
 
 test('ingestLogs only fetches new log entries on repeat runs', async () => {
+    process.env.TARGET_OWNER = 'o';
+    process.env.TARGET_REPO = 'r';
     vi.mock('../src/lib/lock.js', () => ({
       acquireLock: vi.fn().mockResolvedValue(true),
       releaseLock: vi.fn().mockResolvedValue(undefined),

--- a/tests/normalize-roadmap.test.ts
+++ b/tests/normalize-roadmap.test.ts
@@ -66,12 +66,16 @@ beforeEach(() => {
   vi.resetModules();
   process.env.SUPABASE_URL = 'http://example.local';
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+  process.env.TARGET_OWNER = 'o';
+  process.env.TARGET_REPO = 'r';
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
   delete process.env.SUPABASE_URL;
   delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  delete process.env.TARGET_OWNER;
+  delete process.env.TARGET_REPO;
 });
 
 test('sorts and deduplicates roadmap items (happy path)', async () => {

--- a/tests/review-repo.test.ts
+++ b/tests/review-repo.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 
 const envVars = {
-  TARGET_REPO: 'o/r',
+  TARGET_OWNER: 'o',
+  TARGET_REPO: 'r',
   SUPABASE_URL: 'https://supabase.local',
   SUPABASE_SERVICE_ROLE_KEY: 'key',
 };
@@ -16,7 +17,6 @@ vi.mock('../src/lib/lock.js', () => ({
 }));
 
 vi.mock('../src/lib/github.js', () => ({
-  parseRepo: vi.fn().mockReturnValue({ owner: 'o', repo: 'r' }),
   gh: {
     rest: {
       repos: {
@@ -53,12 +53,14 @@ vi.mock('../src/lib/supabase.js', () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  process.env.TARGET_OWNER = envVars.TARGET_OWNER;
   process.env.TARGET_REPO = envVars.TARGET_REPO;
   process.env.SUPABASE_URL = envVars.SUPABASE_URL;
   process.env.SUPABASE_SERVICE_ROLE_KEY = envVars.SUPABASE_SERVICE_ROLE_KEY;
 });
 
 afterEach(() => {
+  delete process.env.TARGET_OWNER;
   delete process.env.TARGET_REPO;
   delete process.env.SUPABASE_URL;
   delete process.env.SUPABASE_SERVICE_ROLE_KEY;

--- a/tests/synthesize-tasks.test.ts
+++ b/tests/synthesize-tasks.test.ts
@@ -2,17 +2,23 @@ import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 
 const SUPABASE_URL = 'https://example.supabase.co';
 const SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+const TARGET_OWNER = 'o';
+const TARGET_REPO = 'r';
 
 beforeEach(() => {
   vi.resetModules();
   process.env.SUPABASE_URL = SUPABASE_URL;
   process.env.SUPABASE_SERVICE_ROLE_KEY = SUPABASE_SERVICE_ROLE_KEY;
+  process.env.TARGET_OWNER = TARGET_OWNER;
+  process.env.TARGET_REPO = TARGET_REPO;
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
   delete process.env.SUPABASE_URL;
   delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  delete process.env.TARGET_OWNER;
+  delete process.env.TARGET_REPO;
 });
 
 test('merges tasks and orders by date', async () => {


### PR DESCRIPTION
## Summary
- expose OWNER and REPO in env and add TARGET_REPO_SLUG helper
- validate OWNER/REPO at startup and use them throughout commands
- update tests and compiled dist files for new env vars

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bb5e5936d8832aa51cf07431af19fe