### PR TITLE
Fix TARGET_OWNER / TARGET_REPO handling

### DIFF
--- a/dist/lib/env.js
+++ b/dist/lib/env.js
@@ -2,6 +2,7 @@
 export const ENV = {
     GH_USERNAME: process.env.GH_USERNAME || "ai-dev-agent",
     PAT_TOKEN: process.env.PAT_TOKEN || "",
+    TARGET_OWNER: process.env.TARGET_OWNER || "",
     TARGET_REPO: process.env.TARGET_REPO || "",
     TARGET_DIR: process.env.TARGET_DIR || "",
     VERCEL_PROJECT_ID: process.env.VERCEL_PROJECT_ID || "",

--- a/dist/lib/github.js
+++ b/dist/lib/github.js
@@ -7,11 +7,19 @@ function formatMessage(msg) {
         return msg;
     return msg.body ? `${msg.title}\n\n${msg.body}` : msg.title;
 }
-export function parseRepo(s) {
-    const [owner, repo] = s.split("/");
-    if (!owner || !repo)
-        throw new Error(`Invalid TARGET_REPO: ${s}`);
-    return { owner, repo };
+export function parseRepo(repoEnv = ENV.TARGET_REPO) {
+    if (!repoEnv)
+        throw new Error("Missing TARGET_REPO");
+    if (repoEnv.includes("/")) {
+        const [owner, repo] = repoEnv.split("/");
+        if (!owner || !repo)
+            throw new Error(`Invalid TARGET_REPO: ${repoEnv}`);
+        return { owner, repo };
+    }
+    const owner = ENV.TARGET_OWNER;
+    if (!owner)
+        throw new Error(`Invalid TARGET_REPO: ${repoEnv}`);
+    return { owner, repo: repoEnv };
 }
 function b64(s) {
     return Buffer.from(s, "utf8").toString("base64");

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -12,10 +12,16 @@ function formatMessage(msg: CommitMessage): string {
   return msg.body ? `${msg.title}\n\n${msg.body}` : msg.title;
 }
 
-export function parseRepo(s: string): RepoRef {
-  const [owner, repo] = s.split("/");
-  if (!owner || !repo) throw new Error(`Invalid TARGET_REPO: ${s}`);
-  return { owner, repo };
+export function parseRepo(repoEnv: string = ENV.TARGET_REPO): RepoRef {
+  if (!repoEnv) throw new Error("Missing TARGET_REPO");
+  if (repoEnv.includes("/")) {
+    const [owner, repo] = repoEnv.split("/");
+    if (!owner || !repo) throw new Error(`Invalid TARGET_REPO: ${repoEnv}`);
+    return { owner, repo };
+  }
+  const owner = ENV.TARGET_OWNER;
+  if (!owner) throw new Error(`Invalid TARGET_REPO: ${repoEnv}`);
+  return { owner, repo: repoEnv };
 }
 
 function b64(s: string) {

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -3,11 +3,15 @@ import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 afterEach(() => {
   vi.restoreAllMocks();
   delete process.env.TARGET_DIR;
+  delete process.env.TARGET_OWNER;
+  delete process.env.TARGET_REPO;
 });
 
 beforeEach(() => {
   vi.resetModules();
   delete process.env.TARGET_DIR;
+  delete process.env.TARGET_OWNER;
+  delete process.env.TARGET_REPO;
 });
 
 test('normalizes mixed path separators', async () => {
@@ -31,4 +35,17 @@ test('prefixes TARGET_DIR when set', async () => {
   const { resolveRepoPath } = await import('../src/lib/github.ts');
   const resolved = resolveRepoPath('file.txt');
   expect(resolved).toBe('base/file.txt');
+});
+
+test('parseRepo handles owner/repo in TARGET_REPO', async () => {
+  process.env.TARGET_REPO = 'basstian-ai/simple-pim-123';
+  const { parseRepo } = await import('../src/lib/github.ts');
+  expect(parseRepo()).toEqual({ owner: 'basstian-ai', repo: 'simple-pim-123' });
+});
+
+test('parseRepo handles separate TARGET_OWNER and TARGET_REPO', async () => {
+  process.env.TARGET_OWNER = 'basstian-ai';
+  process.env.TARGET_REPO = 'simple-pim-123';
+  const { parseRepo } = await import('../src/lib/github.ts');
+  expect(parseRepo()).toEqual({ owner: 'basstian-ai', repo: 'simple-pim-123' });
 });


### PR DESCRIPTION
## Summary
- support TARGET_OWNER + TARGET_REPO or combined TARGET_REPO in parseRepo
- include TARGET_OWNER in compiled env configuration
- test parseRepo for both repository env styles

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bcb5aa33c4832aa9f2d790fb5ac81d