### PR TITLE
Improve TARGET_OWNER / TARGET_REPO handling with better errors and logging

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -13,15 +13,40 @@ function formatMessage(msg: CommitMessage): string {
 }
 
 export function parseRepo(repoEnv: string = ENV.TARGET_REPO): RepoRef {
-  if (!repoEnv) throw new Error("Missing TARGET_REPO");
+  if (!repoEnv) {
+    throw new Error(
+      "Missing TARGET_REPO. Expected either 'owner/repo' or TARGET_OWNER + TARGET_REPO."
+    );
+  }
   if (repoEnv.includes("/")) {
     const [owner, repo] = repoEnv.split("/");
-    if (!owner || !repo) throw new Error(`Invalid TARGET_REPO: ${repoEnv}`);
+    if (!owner || !repo) {
+      throw new Error(
+        `Invalid TARGET_REPO format: "${repoEnv}". Expected "owner/repo".`
+      );
+    }
     return { owner, repo };
   }
-  const owner = ENV.TARGET_OWNER;
-  if (!owner) throw new Error(`Invalid TARGET_REPO: ${repoEnv}`);
-  return { owner, repo: repoEnv };
+  if (!ENV.TARGET_OWNER) {
+    throw new Error(
+      `TARGET_REPO="${repoEnv}" provided without TARGET_OWNER. Please set TARGET_OWNER.`
+    );
+  }
+  return { owner: ENV.TARGET_OWNER, repo: repoEnv };
+}
+
+try {
+  console.log("Resolved repo configuration:", {
+    TARGET_OWNER: ENV.TARGET_OWNER,
+    TARGET_REPO: ENV.TARGET_REPO,
+    parsed: parseRepo(),
+  });
+} catch (err) {
+  console.log("Resolved repo configuration:", {
+    TARGET_OWNER: ENV.TARGET_OWNER,
+    TARGET_REPO: ENV.TARGET_REPO,
+    parsed: (err as Error).message,
+  });
 }
 
 function b64(s: string) {

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -49,3 +49,17 @@ test('parseRepo handles separate TARGET_OWNER and TARGET_REPO', async () => {
   const { parseRepo } = await import('../src/lib/github.ts');
   expect(parseRepo()).toEqual({ owner: 'basstian-ai', repo: 'simple-pim-123' });
 });
+
+test('parseRepo throws if TARGET_REPO is missing', async () => {
+  delete process.env.TARGET_OWNER;
+  delete process.env.TARGET_REPO;
+  const { parseRepo } = await import('../src/lib/github.ts');
+  expect(() => parseRepo()).toThrow(/Missing TARGET_REPO/);
+});
+
+test('parseRepo throws if repo-only provided without owner', async () => {
+  process.env.TARGET_REPO = 'simple-pim-123';
+  delete process.env.TARGET_OWNER;
+  const { parseRepo } = await import('../src/lib/github.ts');
+  expect(() => parseRepo()).toThrow(/TARGET_OWNER/);
+});


### PR DESCRIPTION
## Summary
- provide clearer parseRepo errors when TARGET_REPO or TARGET_OWNER are missing
- log resolved repo configuration at startup for easier debugging
- test parseRepo failure cases for missing env vars

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bd73f75828832ab47f678e0ddf009d