### PR TITLE
refactor: drop Octokit repo hook

### DIFF
--- a/dist/lib/github.js
+++ b/dist/lib/github.js
@@ -27,22 +27,6 @@ export function parseRepo(repoEnv = ENV.TARGET_REPO) {
 function b64(s) {
     return Buffer.from(s, "utf8").toString("base64");
 }
-/**
- * Create Octokit instance that automatically injects {owner, repo}
- * for any repo-scoped route when missing.
- */
-export function createOctokitWithRepo(repo) {
-    const gh = new Octokit({ auth: ENV.PAT_TOKEN });
-    gh.hook.before("request", (options) => {
-        if (typeof options.url === "string" && options.url.includes("/repos/")) {
-            if (options.owner == null)
-                options.owner = repo.owner;
-            if (options.repo == null)
-                options.repo = repo.repo;
-        }
-    });
-    return gh;
-}
 /** Small helper to merge repo params */
 export function withRepo(ref, extra) {
     return { owner: ref.owner, repo: ref.repo, ...extra };

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -42,23 +42,6 @@ function b64(s: string) {
   return Buffer.from(s, "utf8").toString("base64");
 }
 
-/**
- * Create Octokit instance that automatically injects {owner, repo}
- * for any repo-scoped route when missing.
- */
-export function createOctokitWithRepo(repo: RepoRef) {
-  const gh = new Octokit({ auth: ENV.PAT_TOKEN });
-
-  gh.hook.before("request", (options: any) => {
-    if (typeof options.url === "string" && options.url.includes("/repos/")) {
-      if (options.owner == null) options.owner = repo.owner;
-      if (options.repo == null) options.repo = repo.repo;
-    }
-  });
-
-  return gh;
-}
-
 /** Small helper to merge repo params */
 export function withRepo<T extends object>(ref: RepoRef, extra: T): T & RepoRef {
   return { owner: ref.owner, repo: ref.repo, ...extra };


### PR DESCRIPTION
## Summary
- remove the request hook that automatically injected owner/repo into Octokit requests
- expect callers to pass repository context explicitly via `withRepo`

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bdec0b1238832abe4befec4e1de424