### PR TITLE
docs: clarify commit helper usage

### DIFF
--- a/dist/lib/github.js
+++ b/dist/lib/github.js
@@ -87,8 +87,13 @@ export async function createRepoTree(client, repo, files) {
     }
 }
 /**
- * Example high-level commit helper (optional).
- * Use this if you currently hand-wire blob/tree/commit calls.
+ * Commit a set of files using an explicit Octokit client and repository.
+ *
+ * This is a low-level helper that assumes paths are already normalized and
+ * writes all blobs with the default `100644` mode. It does not inspect the
+ * repository for existing permissions or apply any `TARGET_*` environment
+ * configuration. For automation tasks that rely on those conveniences or need
+ * to preserve file modes, use {@link commitMany} instead.
  */
 export async function commitFiles(client, repo, files, message, branch) {
     // 1) create blobs
@@ -190,6 +195,16 @@ export async function upsertFile(path, updater, message, opts) {
         author: { name: "ai-dev-agent", email: "bot@local" }
     });
 }
+/**
+ * Convenience wrapper around {@link commitFiles} that commits multiple files to
+ * the repository defined by `TARGET_REPO`.
+ *
+ * Paths are normalized through {@link resolveRepoPath} and existing file modes
+ * are preserved by inspecting the current tree. Use this in automation
+ * commands where environment configuration and permission retention are
+ * desirable. For generic library usage where you already have an Octokit
+ * instance and repo reference, prefer {@link commitFiles}.
+ */
 export async function commitMany(files, message, opts) {
     const { owner, repo } = parseRepo(ENV.TARGET_REPO);
     const ref = opts?.branch;

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -126,8 +126,13 @@ export async function createRepoTree(
 }
 
 /**
- * Example high-level commit helper (optional).
- * Use this if you currently hand-wire blob/tree/commit calls.
+ * Commit a set of files using an explicit Octokit client and repository.
+ *
+ * This is a low-level helper that assumes paths are already normalized and
+ * writes all blobs with the default `100644` mode. It does not inspect the
+ * repository for existing permissions or apply any `TARGET_*` environment
+ * configuration. For automation tasks that rely on those conveniences or need
+ * to preserve file modes, use {@link commitMany} instead.
  */
 export async function commitFiles(
   client: Octokit,
@@ -253,6 +258,16 @@ export async function upsertFile(
   });
 }
 
+/**
+ * Convenience wrapper around {@link commitFiles} that commits multiple files to
+ * the repository defined by `TARGET_REPO`.
+ *
+ * Paths are normalized through {@link resolveRepoPath} and existing file modes
+ * are preserved by inspecting the current tree. Use this in automation
+ * commands where environment configuration and permission retention are
+ * desirable. For generic library usage where you already have an Octokit
+ * instance and repo reference, prefer {@link commitFiles}.
+ */
 export async function commitMany(
   files: Array<{ path: string; content: string }>,
   message: CommitMessage,


### PR DESCRIPTION
## Summary
- document commitFiles as a low-level helper
- explain commitMany as environment-aware wrapper

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bdec0ec9a8832ab9b313e83883e3a2