### PR TITLE
Add tests for invalid TARGET_REPO formats

### DIFF
--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -63,3 +63,14 @@ test('parseRepo throws if repo-only provided without owner', async () => {
   const { parseRepo } = await import('../src/lib/github.ts');
   expect(() => parseRepo()).toThrow(/TARGET_OWNER/);
 });
+
+test.each(['ownerOnly/', '/repoOnly'])(
+  'parseRepo throws if TARGET_REPO has missing owner or repo: %s',
+  async (repo) => {
+    process.env.TARGET_REPO = repo;
+    const { parseRepo } = await import('../src/lib/github.ts');
+    expect(() => parseRepo()).toThrow(
+      `Invalid TARGET_REPO format: "${repo}". Expected "owner/repo".`
+    );
+  }
+);


### PR DESCRIPTION
## Summary
- add tests to ensure `parseRepo` rejects malformed TARGET_REPO values missing an owner or repo

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bdec185ae0832a975a6e1d8bb72c69