### PR TITLE
refactor: pass repo to getDefaultBranch in ensureBranch

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -195,7 +195,7 @@ export async function ensureBranch(branch: string, baseBranch?: string): Promise
   } catch (e: any) {
     if (e?.status !== 404) throw e;
   }
-  const base = baseBranch || await getDefaultBranch();
+  const base = baseBranch || (await getDefaultBranch(gh, { owner, repo }));
   const baseRef = await gh.rest.git.getRef({ owner, repo, ref: `heads/${base}` });
   const baseSha = baseRef.data.object.sha;
   await gh.rest.git.createRef({ owner, repo, ref: `refs/heads/${branch}`, sha: baseSha });


### PR DESCRIPTION
## Summary
- pass explicit Octokit client and repo to `getDefaultBranch` inside `ensureBranch`

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bdec1b241c832a9808c4e7eb2be3e3