### PR TITLE
refactor: verify commit failure before logging error

### DIFF
--- a/dist/cmds/implement.js
+++ b/dist/cmds/implement.js
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { acquireLock, releaseLock } from "../lib/lock.js";
-import { readFile, commitMany, resolveRepoPath, ensureBranch, getDefaultBranch } from "../lib/github.js";
+import { readFile, commitMany, resolveRepoPath, ensureBranch, getDefaultBranch, gh, parseRepo, } from "../lib/github.js";
 import { implementPlan } from "../lib/prompts.js";
 import { ENV, requireEnv } from "../lib/env.js";
 export async function implementTopTask() {
@@ -132,6 +132,14 @@ export async function implementTopTask() {
                 console.error("Checks or tests failed; aborting commit.", err);
                 return;
             }
+            const branch = targetBranch || await getDefaultBranch();
+            const { owner, repo } = parseRepo();
+            let preSha;
+            try {
+                const ref = await gh.rest.git.getRef({ owner, repo, ref: `heads/${branch}` });
+                preSha = ref.data.object.sha;
+            }
+            catch { }
             try {
                 await commitMany(files, { title, body: commitBody }, { branch: targetBranch });
                 const { completeTask } = await import("../lib/tasks.js");
@@ -139,7 +147,15 @@ export async function implementTopTask() {
                 console.log("Implement complete.");
             }
             catch (err) {
-                console.error("Bulk commit failed; no changes were applied.", err);
+                let postSha;
+                try {
+                    const ref = await gh.rest.git.getRef({ owner, repo, ref: `heads/${branch}` });
+                    postSha = ref.data.object.sha;
+                }
+                catch { }
+                if (preSha === postSha || !files.length) {
+                    console.error("Bulk commit failed; no changes were applied.", err);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- verify commit failure before logging bulk commit error

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bdec1e0bf8832a9ffff8208d8ce43b