### PR TITLE
Fix missing TARGET_REPO resolution and workflow config

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -32,7 +32,7 @@ jobs:
           RUN_TASK: implement
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-          TARGET_REPO: ${{ secrets.TARGET_REPO }}
+          TARGET_REPO: basstian-ai/simple-pim-1754492683911
           TARGET_DIR: ${{ secrets.TARGET_DIR }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}

--- a/.github/workflows/agent-ingest-logs.yml
+++ b/.github/workflows/agent-ingest-logs.yml
@@ -32,7 +32,7 @@ jobs:
           RUN_TASK: ingest-logs
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-          TARGET_REPO: ${{ secrets.TARGET_REPO }}
+          TARGET_REPO: basstian-ai/simple-pim-1754492683911
           TARGET_DIR: ${{ secrets.TARGET_DIR }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}

--- a/.github/workflows/agent-normalize-roadmap.yml
+++ b/.github/workflows/agent-normalize-roadmap.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-          TARGET_REPO: ${{ secrets.TARGET_REPO }}
+          TARGET_REPO: basstian-ai/simple-pim-1754492683911
           TARGET_DIR: ${{ secrets.TARGET_DIR }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}

--- a/.github/workflows/agent-review-repo.yml
+++ b/.github/workflows/agent-review-repo.yml
@@ -32,7 +32,7 @@ jobs:
           RUN_TASK: review-repo
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-          TARGET_REPO: ${{ secrets.TARGET_REPO }}
+          TARGET_REPO: basstian-ai/simple-pim-1754492683911
           TARGET_DIR: ${{ secrets.TARGET_DIR }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}

--- a/.github/workflows/agent-synthesize-tasks.yml
+++ b/.github/workflows/agent-synthesize-tasks.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-          TARGET_REPO: ${{ secrets.TARGET_REPO }}
+          TARGET_REPO: basstian-ai/simple-pim-1754492683911
           TARGET_DIR: ${{ secrets.TARGET_DIR }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -55,6 +55,6 @@ test('parseRepo throws if TARGET_REPO is missing', async () => {
   delete process.env.TARGET_REPO;
   const { parseRepo } = await import('../src/lib/github.ts');
   expect(() => parseRepo()).toThrow(
-    "Missing TARGET_REPO. Expected either 'owner/repo' or TARGET_OWNER + TARGET_REPO."
+    'Missing TARGET_REPO. Received TARGET_OWNER="", TARGET_REPO="".'
   );
 });


### PR DESCRIPTION
## Summary
- log resolved repo configuration before GitHub API calls
- throw clearer parseRepo errors when TARGET_REPO or TARGET_OWNER are missing
- hardcode TARGET_REPO in automation workflows

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bdf3e025a4832a875a8d29a961c88c