### PR TITLE
chore: hardcode TARGET_REPO in implement workflow

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TARGET_REPO: basstian-ai/simple-pim-1754492683911
-      # Or if you prefer to use a secret:
-      # TARGET_REPO: ${{ secrets.TARGET_REPO }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -44,7 +42,6 @@ jobs:
           RUN_TASK: implement
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-          TARGET_REPO: ${{ env.TARGET_REPO }}
           TARGET_DIR: ${{ secrets.TARGET_DIR }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}


### PR DESCRIPTION
## Summary
- stop using GitHub secret for TARGET_REPO in agent-implement workflow
- let orchestrator inherit TARGET_REPO directly from job env

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bdf8c2c374832a93d925463b9e1894