### PR TITLE
feat: support split repo owner and name env vars

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -15,7 +15,8 @@ jobs:
   implement:
     runs-on: ubuntu-latest
     env:
-      TARGET_REPO: basstian-ai/simple-pim-1754492683911
+      TARGET_OWNER: basstian-ai
+      TARGET_REPO: simple-pim-1754492683911
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/dist/cmds/review-repo.js
+++ b/dist/cmds/review-repo.js
@@ -2,7 +2,7 @@ import { acquireLock, releaseLock } from "../lib/lock.js";
 import { parseRepo, gh } from "../lib/github.js";
 import { reviewToIdeas, reviewToSummary } from "../lib/prompts.js";
 import { loadState, saveState, appendChangelog, appendDecision } from "../lib/state.js";
-import { requireEnv, ENV } from "../lib/env.js";
+import { requireEnv } from "../lib/env.js";
 import { sbRequest } from "../lib/supabase.js";
 import yaml from "js-yaml";
 import crypto from "node:crypto";
@@ -20,7 +20,7 @@ export async function reviewRepo() {
         const roadmapTypes = ["vision", "task", "bugs", "done", "new"];
         const [vision, tasks, bugs, done, ideas] = await Promise.all(roadmapTypes.map(fetchRoadmap));
         const state = await loadState();
-        const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+        const { owner, repo } = parseRepo();
         const commitsResp = await gh.rest.repos.listCommits({ owner, repo, per_page: 10 });
         const commitsData = [];
         for (const c of commitsResp.data) {

--- a/dist/orchestrator.js
+++ b/dist/orchestrator.js
@@ -20,7 +20,7 @@ async function shouldReview(state) {
     try {
         if (!ENV.TARGET_REPO)
             return false;
-        const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+        const { owner, repo } = parseRepo();
         const resp = await gh.rest.repos.listCommits({ owner, repo, per_page: 1 });
         const latest = resp.data[0]?.sha;
         return !!latest && latest !== state.lastReviewedSha;

--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -23,7 +23,7 @@ export async function reviewRepo() {
     );
 
     const state = await loadState();
-    const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+    const { owner, repo } = parseRepo();
     const commitsResp = await gh.rest.repos.listCommits({ owner, repo, per_page: 10 });
     const commitsData = [] as { sha: string; commit: { message: string } }[];
     for (const c of commitsResp.data) {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -19,7 +19,7 @@ async function shouldIngest(state: AgentState): Promise<boolean> {
 async function shouldReview(state: AgentState): Promise<boolean> {
   try {
     if (!ENV.TARGET_REPO) return false;
-    const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+    const { owner, repo } = parseRepo();
     const resp = await gh.rest.repos.listCommits({ owner, repo, per_page: 1 });
     const latest = resp.data[0]?.sha;
     return !!latest && latest !== state.lastReviewedSha;

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -55,6 +55,6 @@ test('parseRepo throws if TARGET_REPO is missing', async () => {
   delete process.env.TARGET_REPO;
   const { parseRepo } = await import('../src/lib/github.ts');
   expect(() => parseRepo()).toThrow(
-    'Missing TARGET_REPO. Received TARGET_OWNER="", TARGET_REPO="".'
+    'Invalid repo config. Got TARGET_OWNER="" TARGET_REPO="". Expected either TARGET_OWNER + TARGET_REPO or TARGET_REPO="owner/repo".'
   );
 });


### PR DESCRIPTION
## Summary
- support explicit TARGET_OWNER and TARGET_REPO env vars in parseRepo
- adjust orchestrator and review flows to use new repo parsing
- set TARGET_OWNER and TARGET_REPO separately in implement workflow

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bdfbd5dacc832ab8d5db3b3ea15913