### PR TITLE
chore: add workflow debug auth step

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -18,6 +18,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
+      - name: Debug GitHub auth
+        run: |
+          curl -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
+               https://api.github.com/repos/basstian-ai/simple-pim-1754492683911
       - name: Ensure lockfile (first run)
         run: |
           if [ ! -f package-lock.json ]; then


### PR DESCRIPTION
## Summary
- add debug step to verify PAT access via GitHub API

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68be6f1adca0832aa6d3e45b26175783