### PR TITLE
fix: secure TARGET_REPO handling in implement workflow

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -33,14 +33,12 @@ jobs:
 
       - name: Debug env
         run: echo "DEBUG ENV TARGET_REPO=$TARGET_REPO"
-
       - run: node dist/orchestrator.js
         env:
           RUN_TASK: implement
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-          # 👇 hardcoded repo instead of secret
-          TARGET_REPO: basstian-ai/simple-pim-1754492683911
+          TARGET_REPO: ${{ secrets.TARGET_REPO }}
           TARGET_DIR: ${{ secrets.TARGET_DIR }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}


### PR DESCRIPTION
## Summary
- reference TARGET_REPO via repository secret
- avoid hardcoded repo in implement workflow

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68be774b767c832a94f5e215d1b330dc