### PR TITLE
test: add vitest imports

### DIFF
--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { parseRepo } from "../src/env";
 
 describe("parseRepo", () => {


### PR DESCRIPTION
## Summary
- import vitest helpers into github environment tests to fix ReferenceError

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be972c2188832a95c6241256076f3a