### PR TITLE
Require explicit owner and repo for GitHub operations

### DIFF
--- a/dist/cmds/implement.js
+++ b/dist/cmds/implement.js
@@ -10,7 +10,7 @@ export async function implementTopTask() {
         return;
     }
     try {
-        requireEnv(['TARGET_REPO']);
+        requireEnv(['TARGET_OWNER', 'TARGET_REPO']);
         const { supabase } = await import("../lib/supabase.js");
         // Load vision for context
         const vision = (await readFile("roadmap/vision.md")) || "";

--- a/dist/cmds/review-repo.js
+++ b/dist/cmds/review-repo.js
@@ -2,7 +2,7 @@ import { acquireLock, releaseLock } from "../lib/lock.js";
 import { parseRepo, gh } from "../lib/github.js";
 import { reviewToIdeas, reviewToSummary } from "../lib/prompts.js";
 import { loadState, saveState, appendChangelog, appendDecision } from "../lib/state.js";
-import { requireEnv, ENV } from "../lib/env.js";
+import { requireEnv } from "../lib/env.js";
 import { sbRequest } from "../lib/supabase.js";
 import yaml from "js-yaml";
 import crypto from "node:crypto";
@@ -12,7 +12,7 @@ export async function reviewRepo() {
         return;
     }
     try {
-        requireEnv(["TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+        requireEnv(["TARGET_OWNER", "TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
         async function fetchRoadmap(type) {
             const data = (await sbRequest(`roadmap_items?select=content&type=eq.${type}`));
             return data ? data.map((r) => r.content).join("\n") : "";
@@ -20,7 +20,7 @@ export async function reviewRepo() {
         const roadmapTypes = ["vision", "task", "bugs", "done", "new"];
         const [vision, tasks, bugs, done, ideas] = await Promise.all(roadmapTypes.map(fetchRoadmap));
         const state = await loadState();
-        const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+        const { owner, repo } = parseRepo();
         const commitsResp = await gh.rest.repos.listCommits({ owner, repo, per_page: 10 });
         const commitsData = [];
         for (const c of commitsResp.data) {

--- a/dist/env.js
+++ b/dist/env.js
@@ -1,0 +1,18 @@
+/**
+ * Resolve repository configuration from environment variables.
+ *
+ * Required:
+ *   - TARGET_OWNER (e.g. "basstian-ai")
+ *   - TARGET_REPO (e.g. "simple-pim-1754492683911")
+ */
+export function parseRepo() {
+    const targetOwner = process.env.TARGET_OWNER;
+    const targetRepo = process.env.TARGET_REPO;
+    if (!targetOwner || !targetRepo) {
+        throw new Error("Missing required TARGET_OWNER and TARGET_REPO environment variables");
+    }
+    return {
+        owner: targetOwner,
+        repo: targetRepo,
+    };
+}

--- a/dist/lib/env.js
+++ b/dist/lib/env.js
@@ -2,6 +2,7 @@
 export const ENV = {
     GH_USERNAME: process.env.GH_USERNAME || "ai-dev-agent",
     PAT_TOKEN: process.env.PAT_TOKEN || "",
+    TARGET_OWNER: process.env.TARGET_OWNER || "",
     TARGET_REPO: process.env.TARGET_REPO || "",
     TARGET_DIR: process.env.TARGET_DIR || "",
     VERCEL_PROJECT_ID: process.env.VERCEL_PROJECT_ID || "",

--- a/dist/orchestrator.js
+++ b/dist/orchestrator.js
@@ -18,9 +18,9 @@ async function shouldIngest(state) {
 }
 async function shouldReview(state) {
     try {
-        if (!ENV.TARGET_REPO)
+        if (!ENV.TARGET_OWNER || !ENV.TARGET_REPO)
             return false;
-        const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+        const { owner, repo } = parseRepo();
         const resp = await gh.rest.repos.listCommits({ owner, repo, per_page: 1 });
         const latest = resp.data[0]?.sha;
         return !!latest && latest !== state.lastReviewedSha;

--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -18,7 +18,7 @@ type RoadmapItem = {
 export async function implementTopTask() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
-    requireEnv(['TARGET_REPO']);
+    requireEnv(['TARGET_OWNER', 'TARGET_REPO']);
     const { supabase } = await import("../lib/supabase.js");
     // Load vision for context
     const vision = (await readFile("roadmap/vision.md")) || "";

--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -10,7 +10,7 @@ import crypto from "node:crypto";
 export async function reviewRepo() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
-    requireEnv(["TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+    requireEnv(["TARGET_OWNER", "TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
     async function fetchRoadmap(type: string) {
       const data = (await sbRequest(
         `roadmap_items?select=content&type=eq.${type}`,
@@ -23,7 +23,7 @@ export async function reviewRepo() {
     );
 
     const state = await loadState();
-    const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+    const { owner, repo } = parseRepo();
     const commitsResp = await gh.rest.repos.listCommits({ owner, repo, per_page: 10 });
     const commitsData = [] as { sha: string; commit: { message: string } }[];
     for (const c of commitsResp.data) {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -2,6 +2,7 @@
 export const ENV = {
   GH_USERNAME: process.env.GH_USERNAME || "ai-dev-agent",
   PAT_TOKEN: process.env.PAT_TOKEN || "",
+  TARGET_OWNER: process.env.TARGET_OWNER || "",
   TARGET_REPO: process.env.TARGET_REPO || "",
   TARGET_DIR: process.env.TARGET_DIR || "",
   VERCEL_PROJECT_ID: process.env.VERCEL_PROJECT_ID || "",

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -18,8 +18,8 @@ async function shouldIngest(state: AgentState): Promise<boolean> {
 
 async function shouldReview(state: AgentState): Promise<boolean> {
   try {
-    if (!ENV.TARGET_REPO) return false;
-    const { owner, repo } = parseRepo(ENV.TARGET_REPO);
+    if (!ENV.TARGET_OWNER || !ENV.TARGET_REPO) return false;
+    const { owner, repo } = parseRepo();
     const resp = await gh.rest.repos.listCommits({ owner, repo, per_page: 1 });
     const latest = resp.data[0]?.sha;
     return !!latest && latest !== state.lastReviewedSha;

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { parseRepo } from "../src/env";
+import { gh, getDefaultBranch } from "../src/lib/github";
 
 describe("parseRepo", () => {
   it("parses separate TARGET_OWNER and TARGET_REPO", () => {
@@ -24,5 +25,17 @@ describe("parseRepo", () => {
     delete process.env.TARGET_OWNER;
     delete process.env.TARGET_REPO;
     expect(() => parseRepo()).toThrow("Missing required TARGET_OWNER and TARGET_REPO");
+  });
+});
+
+describe("Octokit integration", () => {
+  it("passes owner and repo to API calls", async () => {
+    process.env.TARGET_OWNER = "foo";
+    process.env.TARGET_REPO = "bar";
+    const spy = vi
+      .spyOn(gh.rest.repos, "get")
+      .mockResolvedValue({ data: { default_branch: "main" } } as any);
+    await getDefaultBranch();
+    expect(spy).toHaveBeenCalledWith({ owner: "foo", repo: "bar" });
   });
 });

--- a/tests/implement.test.ts
+++ b/tests/implement.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 
 beforeEach(() => {
   vi.resetModules();
+  delete process.env.TARGET_OWNER;
   delete process.env.TARGET_REPO;
 });
 
@@ -10,6 +11,7 @@ afterEach(() => {
 });
 
 test('implementTopTask throws when TARGET_REPO missing', async () => {
+  process.env.TARGET_OWNER = 'o';
   vi.mock('../src/lib/lock.js', () => ({
     acquireLock: vi.fn().mockResolvedValue(true),
     releaseLock: vi.fn().mockResolvedValue(undefined),

--- a/tests/review-repo.test.ts
+++ b/tests/review-repo.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 
 const envVars = {
-  TARGET_REPO: 'o/r',
+  TARGET_OWNER: 'o',
+  TARGET_REPO: 'r',
   SUPABASE_URL: 'https://supabase.local',
   SUPABASE_SERVICE_ROLE_KEY: 'key',
 };
@@ -53,12 +54,14 @@ vi.mock('../src/lib/supabase.js', () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  process.env.TARGET_OWNER = envVars.TARGET_OWNER;
   process.env.TARGET_REPO = envVars.TARGET_REPO;
   process.env.SUPABASE_URL = envVars.SUPABASE_URL;
   process.env.SUPABASE_SERVICE_ROLE_KEY = envVars.SUPABASE_SERVICE_ROLE_KEY;
 });
 
 afterEach(() => {
+  delete process.env.TARGET_OWNER;
   delete process.env.TARGET_REPO;
   delete process.env.SUPABASE_URL;
   delete process.env.SUPABASE_SERVICE_ROLE_KEY;


### PR DESCRIPTION
## Summary
- Parse TARGET_OWNER and TARGET_REPO separately
- Pass owner and repo to Octokit operations and commands
- Add unit test covering Octokit call

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68beff28d0b0832ab133ef958c6d5b5c