### PR TITLE
refactor: centralize repo env handling

### DIFF
--- a/dist/cmds/implement.js
+++ b/dist/cmds/implement.js
@@ -3,14 +3,13 @@ import { readFileSync } from "node:fs";
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { readFile, commitMany, resolveRepoPath, ensureBranch, getDefaultBranch } from "../lib/github.js";
 import { implementPlan } from "../lib/prompts.js";
-import { ENV, requireEnv } from "../lib/env.js";
+import { ENV } from "../lib/env.js";
 export async function implementTopTask() {
     if (!(await acquireLock())) {
         console.log("Lock taken; exiting.");
         return;
     }
     try {
-        requireEnv(['TARGET_OWNER', 'TARGET_REPO']);
         const { supabase } = await import("../lib/supabase.js");
         // Load vision for context
         const vision = (await readFile("roadmap/vision.md")) || "";

--- a/dist/cmds/review-repo.js
+++ b/dist/cmds/review-repo.js
@@ -12,7 +12,7 @@ export async function reviewRepo() {
         return;
     }
     try {
-        requireEnv(["TARGET_OWNER", "TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+        requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
         async function fetchRoadmap(type) {
             const data = (await sbRequest(`roadmap_items?select=content&type=eq.${type}`));
             return data ? data.map((r) => r.content).join("\n") : "";

--- a/dist/env.js
+++ b/dist/env.js
@@ -1,3 +1,4 @@
+import { requireEnv } from "./lib/env.js";
 /**
  * Resolve repository configuration from environment variables.
  *
@@ -6,13 +7,9 @@
  *   - TARGET_REPO (e.g. "simple-pim-1754492683911")
  */
 export function parseRepo() {
-    const targetOwner = process.env.TARGET_OWNER;
-    const targetRepo = process.env.TARGET_REPO;
-    if (!targetOwner || !targetRepo) {
-        throw new Error("Missing required TARGET_OWNER and TARGET_REPO environment variables");
-    }
+    requireEnv(["TARGET_OWNER", "TARGET_REPO"]);
     return {
-        owner: targetOwner,
-        repo: targetRepo,
+        owner: process.env.TARGET_OWNER,
+        repo: process.env.TARGET_REPO,
     };
 }

--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { readFile, commitMany, resolveRepoPath, ensureBranch, getDefaultBranch } from "../lib/github.js";
 import { implementPlan } from "../lib/prompts.js";
-import { ENV, requireEnv } from "../lib/env.js";
+import { ENV } from "../lib/env.js";
 
 type RoadmapItem = {
   id?: string;
@@ -18,7 +18,6 @@ type RoadmapItem = {
 export async function implementTopTask() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
-    requireEnv(['TARGET_OWNER', 'TARGET_REPO']);
     const { supabase } = await import("../lib/supabase.js");
     // Load vision for context
     const vision = (await readFile("roadmap/vision.md")) || "";

--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -2,7 +2,7 @@ import { acquireLock, releaseLock } from "../lib/lock.js";
 import { parseRepo, gh } from "../lib/github.js";
 import { reviewToIdeas, reviewToSummary } from "../lib/prompts.js";
 import { loadState, saveState, appendChangelog, appendDecision } from "../lib/state.js";
-import { requireEnv, ENV } from "../lib/env.js";
+import { requireEnv } from "../lib/env.js";
 import { sbRequest } from "../lib/supabase.js";
 import yaml from "js-yaml";
 import crypto from "node:crypto";
@@ -10,7 +10,7 @@ import crypto from "node:crypto";
 export async function reviewRepo() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
-    requireEnv(["TARGET_OWNER", "TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
     async function fetchRoadmap(type: string) {
       const data = (await sbRequest(
         `roadmap_items?select=content&type=eq.${type}`,

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,20 +1,16 @@
+import { requireEnv } from "./lib/env.js";
+
 /**
  * Resolve repository configuration from environment variables.
- * 
+ *
  * Required:
  *   - TARGET_OWNER (e.g. "basstian-ai")
  *   - TARGET_REPO (e.g. "simple-pim-1754492683911")
  */
 export function parseRepo(): { owner: string; repo: string } {
-  const targetOwner = process.env.TARGET_OWNER;
-  const targetRepo = process.env.TARGET_REPO;
-
-  if (!targetOwner || !targetRepo) {
-    throw new Error("Missing required TARGET_OWNER and TARGET_REPO environment variables");
-  }
-
+  requireEnv(["TARGET_OWNER", "TARGET_REPO"]);
   return {
-    owner: targetOwner,
-    repo: targetRepo,
+    owner: process.env.TARGET_OWNER!,
+    repo: process.env.TARGET_REPO!,
   };
 }

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -12,19 +12,19 @@ describe("parseRepo", () => {
   it("throws when missing TARGET_OWNER", () => {
     delete process.env.TARGET_OWNER;
     process.env.TARGET_REPO = "bar";
-    expect(() => parseRepo()).toThrow("Missing required TARGET_OWNER and TARGET_REPO");
+    expect(() => parseRepo()).toThrow("Missing env: TARGET_OWNER");
   });
 
   it("throws when missing TARGET_REPO", () => {
     process.env.TARGET_OWNER = "foo";
     delete process.env.TARGET_REPO;
-    expect(() => parseRepo()).toThrow("Missing required TARGET_OWNER and TARGET_REPO");
+    expect(() => parseRepo()).toThrow("Missing env: TARGET_REPO");
   });
 
   it("throws when both missing", () => {
     delete process.env.TARGET_OWNER;
     delete process.env.TARGET_REPO;
-    expect(() => parseRepo()).toThrow("Missing required TARGET_OWNER and TARGET_REPO");
+    expect(() => parseRepo()).toThrow("Missing env: TARGET_OWNER");
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure parseRepo asserts TARGET_OWNER/TARGET_REPO via requireEnv
- drop redundant env assertions from implement and review-repo commands
- update tests for new error messages

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c00e40f2d8832aa65c2037c6e1707c