### PR TITLE
Expose target repo variables in workflows

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -29,6 +29,12 @@ jobs:
       ALLOW_PATHS: ""
 
     steps:
+      - name: Verify target repository variables
+        run: |
+          if [ -z "${TARGET_OWNER}" ] || [ -z "${TARGET_REPO}" ]; then
+            echo "TARGET_OWNER and TARGET_REPO must be set"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/agent-ingest-logs.yml
+++ b/.github/workflows/agent-ingest-logs.yml
@@ -14,7 +14,16 @@ concurrency:
 jobs:
   ingest-logs:
     runs-on: ubuntu-latest
+    env:
+      TARGET_OWNER: ${{ secrets.TARGET_OWNER }}
+      TARGET_REPO: ${{ secrets.TARGET_REPO }}
     steps:
+      - name: Verify target repository variables
+        run: |
+          if [ -z "${TARGET_OWNER}" ] || [ -z "${TARGET_REPO}" ]; then
+            echo "TARGET_OWNER and TARGET_REPO must be set"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
@@ -32,7 +41,6 @@ jobs:
           RUN_TASK: ingest-logs
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-          TARGET_REPO: ${{ secrets.TARGET_REPO }}
           TARGET_DIR: ${{ secrets.TARGET_DIR }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}

--- a/.github/workflows/agent-normalize-roadmap.yml
+++ b/.github/workflows/agent-normalize-roadmap.yml
@@ -14,7 +14,16 @@ concurrency:
 jobs:
   normalize-roadmap:
     runs-on: ubuntu-latest
+    env:
+      TARGET_OWNER: ${{ secrets.TARGET_OWNER }}
+      TARGET_REPO: ${{ secrets.TARGET_REPO }}
     steps:
+      - name: Verify target repository variables
+        run: |
+          if [ -z "${TARGET_OWNER}" ] || [ -z "${TARGET_REPO}" ]; then
+            echo "TARGET_OWNER and TARGET_REPO must be set"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
@@ -31,7 +40,6 @@ jobs:
         env:
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-          TARGET_REPO: ${{ secrets.TARGET_REPO }}
           TARGET_DIR: ${{ secrets.TARGET_DIR }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}

--- a/.github/workflows/agent-review-repo.yml
+++ b/.github/workflows/agent-review-repo.yml
@@ -14,7 +14,16 @@ concurrency:
 jobs:
   review-repo:
     runs-on: ubuntu-latest
+    env:
+      TARGET_OWNER: ${{ secrets.TARGET_OWNER }}
+      TARGET_REPO: ${{ secrets.TARGET_REPO }}
     steps:
+      - name: Verify target repository variables
+        run: |
+          if [ -z "${TARGET_OWNER}" ] || [ -z "${TARGET_REPO}" ]; then
+            echo "TARGET_OWNER and TARGET_REPO must be set"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
@@ -32,7 +41,6 @@ jobs:
           RUN_TASK: review-repo
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-          TARGET_REPO: ${{ secrets.TARGET_REPO }}
           TARGET_DIR: ${{ secrets.TARGET_DIR }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}

--- a/.github/workflows/agent-synthesize-tasks.yml
+++ b/.github/workflows/agent-synthesize-tasks.yml
@@ -14,7 +14,16 @@ concurrency:
 jobs:
   synthesize-tasks:
     runs-on: ubuntu-latest
+    env:
+      TARGET_OWNER: ${{ secrets.TARGET_OWNER }}
+      TARGET_REPO: ${{ secrets.TARGET_REPO }}
     steps:
+      - name: Verify target repository variables
+        run: |
+          if [ -z "${TARGET_OWNER}" ] || [ -z "${TARGET_REPO}" ]; then
+            echo "TARGET_OWNER and TARGET_REPO must be set"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
@@ -31,7 +40,6 @@ jobs:
         env:
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-          TARGET_REPO: ${{ secrets.TARGET_REPO }}
           TARGET_DIR: ${{ secrets.TARGET_DIR }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,16 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      TARGET_OWNER: ${{ secrets.TARGET_OWNER }}
+      TARGET_REPO: ${{ secrets.TARGET_REPO }}
     steps:
+      - name: Verify target repository variables
+        run: |
+          if [ -z "${TARGET_OWNER}" ] || [ -z "${TARGET_REPO}" ]; then
+            echo "TARGET_OWNER and TARGET_REPO must be set"
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -18,9 +27,6 @@ jobs:
 
       - name: Run orchestrator
         run: node dist/orchestrator.js
-        env:
-          TARGET_OWNER: ${{ secrets.TARGET_OWNER }}
-          TARGET_REPO: ${{ secrets.TARGET_REPO }}
 
       # Required secrets for orchestrator:
       #   - TARGET_OWNER (e.g. "basstian-ai")


### PR DESCRIPTION
## Summary
- define `TARGET_OWNER` and `TARGET_REPO` at the job level for all workflows
- add early steps to verify required target variables are set

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c00e422ce8832a970ffe7fa9283c24