### PR TITLE
Clone target repository before scanning

### DIFF
--- a/.github/workflows/agent-review-repo.yml
+++ b/.github/workflows/agent-review-repo.yml
@@ -32,6 +32,7 @@ jobs:
           RUN_TASK: review-repo
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          TARGET_OWNER: ${{ secrets.TARGET_OWNER }}
           TARGET_REPO: ${{ secrets.TARGET_REPO }}
           TARGET_DIR: ${{ secrets.TARGET_DIR }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/automation/review-repo.ts
+++ b/automation/review-repo.ts
@@ -1,9 +1,23 @@
 import { promises as fs } from "fs";
 import path from "node:path";
 import crypto from "node:crypto";
+import { exec as execCb } from "node:child_process";
+import { promisify } from "node:util";
 import { planRepo } from "./prompt";
 
-const TARGET_PATH = process.env.TARGET_PATH || "target";
+const exec = promisify(execCb);
+
+const TARGET_OWNER = process.env.TARGET_OWNER;
+const TARGET_REPO = process.env.TARGET_REPO;
+const TARGET_DIR = process.env.TARGET_DIR || "";
+
+if (!TARGET_OWNER || !TARGET_REPO) {
+  console.error("Missing required env TARGET_OWNER or TARGET_REPO");
+  process.exit(1);
+}
+
+const CLONE_PATH = process.env.TARGET_PATH || "target";
+const REPO_PATH = path.join(CLONE_PATH, TARGET_DIR);
 const MAX_FILES = Number(process.env.MAX_FILES || 180);
 const MAX_SAMPLED_FILES = Number(process.env.MAX_SAMPLED_FILES || 80);
 const MAX_BYTES = Number(process.env.MAX_BYTES_PER_FILE || 1500);
@@ -95,8 +109,14 @@ async function scanRepo(root: string) {
   return { files, dirs, duplicates };
 }
 
+async function cloneRepo() {
+  await fs.rm(CLONE_PATH, { recursive: true, force: true });
+  const url = `https://github.com/${TARGET_OWNER}/${TARGET_REPO}.git`;
+  await exec(`git clone --depth 1 ${url} ${CLONE_PATH}`);
+}
+
 async function writeFileSafe(p: string, content: string) {
-  const rel = path.relative(TARGET_PATH, p).replace(/\\/g, "/");
+  const rel = path.relative(REPO_PATH, p).replace(/\\/g, "/");
   if (PROTECTED_PATHS.includes(rel)) {
     throw new Error(`Refusing to write protected path: ${rel}`);
   }
@@ -106,7 +126,8 @@ async function writeFileSafe(p: string, content: string) {
 }
 
 async function main() {
-  const { files, dirs, duplicates } = await scanRepo(TARGET_PATH);
+  await cloneRepo();
+  const { files, dirs, duplicates } = await scanRepo(REPO_PATH);
   const truncated = files.length >= MAX_FILES || files.length >= MAX_SAMPLED_FILES;
   console.log(`Scanned ${files.length} files in ${dirs.length} dirs${truncated ? " (truncated)" : ""}`);
   if (duplicates.length) {
@@ -114,7 +135,7 @@ async function main() {
   }
 
   const topLevel = dirs.filter(d => !d.path.includes(path.sep)).map(d => d.path);
-  const auditPath = path.join(TARGET_PATH, "audits", "repo-structure.md");
+  const auditPath = path.join(REPO_PATH, "audits", "repo-structure.md");
   const dupLines = duplicates.length
     ? duplicates.flatMap(d => [`- ${d.base}`, ...d.members.map(m => `  - ${m}`)])
     : ["- none"];
@@ -203,7 +224,15 @@ async function main() {
   const roadmapTasks = await fetchRoadmap("task");
   const vision = await (async () => {
     for (const rel of ["vision.md", "roadmap/vision.md"]) {
-      try { return { path: rel, content: trim(await fs.readFile(path.join(TARGET_PATH, rel), "utf8"), READ_LIMIT) }; } catch {}
+      try {
+        return {
+          path: rel,
+          content: trim(
+            await fs.readFile(path.join(REPO_PATH, rel), "utf8"),
+            READ_LIMIT,
+          ),
+        };
+      } catch {}
     }
     return { path: "", content: "" };
   })();


### PR DESCRIPTION
## Summary
- allow automation review script to take TARGET_OWNER/TARGET_REPO and optional TARGET_DIR
- clone the target repository and scan the specified directory
- pass TARGET_OWNER through agent-review-repo workflow

## Testing
- `npm test`
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c00e435a0c832abb51024b9ad899b3