### PR TITLE
refactor: rely on parseRepo for repo env

### DIFF
--- a/dist/cmds/implement.js
+++ b/dist/cmds/implement.js
@@ -3,14 +3,13 @@ import { readFileSync } from "node:fs";
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { readFile, commitMany, resolveRepoPath, ensureBranch, getDefaultBranch } from "../lib/github.js";
 import { implementPlan } from "../lib/prompts.js";
-import { ENV, requireEnv } from "../lib/env.js";
+import { ENV } from "../lib/env.js";
 export async function implementTopTask() {
     if (!(await acquireLock())) {
         console.log("Lock taken; exiting.");
         return;
     }
     try {
-        requireEnv(['TARGET_OWNER', 'TARGET_REPO']);
         const { supabase } = await import("../lib/supabase.js");
         // Load vision for context
         const vision = (await readFile("roadmap/vision.md")) || "";

--- a/dist/cmds/review-repo.js
+++ b/dist/cmds/review-repo.js
@@ -1,8 +1,8 @@
 import { acquireLock, releaseLock } from "../lib/lock.js";
-import { parseRepo, gh } from "../lib/github.js";
+import { gh } from "../lib/github.js";
+import { parseRepo, requireEnv } from "../lib/env.js";
 import { reviewToIdeas, reviewToSummary } from "../lib/prompts.js";
 import { loadState, saveState, appendChangelog, appendDecision } from "../lib/state.js";
-import { requireEnv } from "../lib/env.js";
 import { sbRequest } from "../lib/supabase.js";
 import yaml from "js-yaml";
 import crypto from "node:crypto";
@@ -12,7 +12,7 @@ export async function reviewRepo() {
         return;
     }
     try {
-        requireEnv(["TARGET_OWNER", "TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+        requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
         async function fetchRoadmap(type) {
             const data = (await sbRequest(`roadmap_items?select=content&type=eq.${type}`));
             return data ? data.map((r) => r.content).join("\n") : "";

--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { readFile, commitMany, resolveRepoPath, ensureBranch, getDefaultBranch } from "../lib/github.js";
 import { implementPlan } from "../lib/prompts.js";
-import { ENV, requireEnv } from "../lib/env.js";
+import { ENV } from "../lib/env.js";
 
 type RoadmapItem = {
   id?: string;
@@ -18,7 +18,6 @@ type RoadmapItem = {
 export async function implementTopTask() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
-    requireEnv(['TARGET_OWNER', 'TARGET_REPO']);
     const { supabase } = await import("../lib/supabase.js");
     // Load vision for context
     const vision = (await readFile("roadmap/vision.md")) || "";

--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -1,9 +1,8 @@
 import { acquireLock, releaseLock } from "../lib/lock.js";
 import { gh } from "../lib/github.js";
-import { parseRepo } from "../lib/env.js";
+import { parseRepo, requireEnv } from "../lib/env.js";
 import { reviewToIdeas, reviewToSummary } from "../lib/prompts.js";
 import { loadState, saveState, appendChangelog, appendDecision } from "../lib/state.js";
-import { requireEnv, ENV } from "../lib/env.js";
 import { sbRequest } from "../lib/supabase.js";
 import yaml from "js-yaml";
 import crypto from "node:crypto";
@@ -11,7 +10,7 @@ import crypto from "node:crypto";
 export async function reviewRepo() {
   if (!(await acquireLock())) { console.log("Lock taken; exiting."); return; }
   try {
-    requireEnv(["TARGET_OWNER", "TARGET_REPO", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
     async function fetchRoadmap(type: string) {
       const data = (await sbRequest(
         `roadmap_items?select=content&type=eq.${type}`,

--- a/tests/implement.test.ts
+++ b/tests/implement.test.ts
@@ -17,6 +17,6 @@ test('implementTopTask throws when TARGET_REPO missing', async () => {
     releaseLock: vi.fn().mockResolvedValue(undefined),
   }));
   const { implementTopTask } = await import('../src/cmds/implement.ts');
-  await expect(implementTopTask()).rejects.toThrow('Missing env: TARGET_REPO');
+  await expect(implementTopTask()).rejects.toThrow('Missing required TARGET_OWNER and TARGET_REPO environment variables');
 });
 

--- a/tests/review-repo.test.ts
+++ b/tests/review-repo.test.ts
@@ -73,6 +73,12 @@ test('reviewRepo throws on invalid ideas YAML', async () => {
   expect(saveState).not.toHaveBeenCalled();
 });
 
+test('reviewRepo throws when repo env vars are missing', async () => {
+  delete process.env.TARGET_OWNER;
+  const { reviewRepo } = await import('../src/cmds/review-repo.ts');
+  await expect(reviewRepo()).rejects.toThrow('Missing required TARGET_OWNER and TARGET_REPO environment variables');
+});
+
 test('reviewRepo batches ideas and generates unique IDs', async () => {
   const { reviewRepo } = await import('../src/cmds/review-repo.ts');
   reviewToIdeas.mockResolvedValue(


### PR DESCRIPTION
## Summary
- drop explicit TARGET_OWNER/TARGET_REPO checks in implement and review-repo commands
- rely on parseRepo to validate repository env vars
- update tests for new error paths

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c070f49cb0832abcca0924375a01f6