### PR TITLE
refactor: rely on parseRepo for review env

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -4,7 +4,7 @@ import { implementTopTask } from "./cmds/implement.js";
 import { loadState, type AgentState } from "./lib/state.js";
 import { getLatestDeployment } from "./lib/vercel.js";
 import { gh } from "./lib/github.js";
-import { ENV, parseRepo } from "./lib/env.js";
+import { parseRepo } from "./lib/env.js";
 
 async function shouldIngest(state: AgentState): Promise<boolean> {
   try {
@@ -18,7 +18,6 @@ async function shouldIngest(state: AgentState): Promise<boolean> {
 
 async function shouldReview(state: AgentState): Promise<boolean> {
   try {
-    if (!ENV.TARGET_OWNER || !ENV.TARGET_REPO) return false;
     const { owner, repo } = parseRepo();
     const resp = await gh.rest.repos.listCommits({ owner, repo, per_page: 1 });
     const latest = resp.data[0]?.sha;


### PR DESCRIPTION
## Summary
- remove manual TARGET_OWNER/TARGET_REPO check in orchestrator shouldReview
- rely on parseRepo throwing to skip review when env vars missing

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c074c5eb2c832a9ade738da1a48112