### PR TITLE
Refactor repo review script to clone target repository

### DIFF
--- a/automation/review-repo.ts
+++ b/automation/review-repo.ts
@@ -52,9 +52,13 @@ function dirSignature(entries: string[]) {
 }
 
 async function ensureRepo() {
-  const gitUrl = `https://github.com/${TARGET_OWNER}/${TARGET_REPO}.git`;
+  const ghUser = process.env.GH_USERNAME;
+  const pat = process.env.PAT_TOKEN;
+  const auth = ghUser && pat ? `${encodeURIComponent(ghUser)}:${encodeURIComponent(pat)}@` : "";
+  const gitUrl = `https://${auth}github.com/${TARGET_OWNER}/${TARGET_REPO}.git`;
   try {
     await fs.access(path.join(TARGET_PATH, ".git"));
+    await exec(`git -C ${TARGET_PATH} remote set-url origin ${gitUrl}`);
     await exec(`git -C ${TARGET_PATH} pull --ff-only`);
   } catch {
     await fs.mkdir(path.dirname(TARGET_PATH), { recursive: true });

--- a/dist/automation/review-repo.js
+++ b/dist/automation/review-repo.js
@@ -45,9 +45,13 @@ function dirSignature(entries) {
     return crypto.createHash("md5").update(sig).digest("hex");
 }
 async function ensureRepo() {
-    const gitUrl = `https://github.com/${TARGET_OWNER}/${TARGET_REPO}.git`;
+    const ghUser = process.env.GH_USERNAME;
+    const pat = process.env.PAT_TOKEN;
+    const auth = ghUser && pat ? `${encodeURIComponent(ghUser)}:${encodeURIComponent(pat)}@` : "";
+    const gitUrl = `https://${auth}github.com/${TARGET_OWNER}/${TARGET_REPO}.git`;
     try {
         await fs.access(path.join(TARGET_PATH, ".git"));
+        await exec(`git -C ${TARGET_PATH} remote set-url origin ${gitUrl}`);
         await exec(`git -C ${TARGET_PATH} pull --ff-only`);
     }
     catch {


### PR DESCRIPTION
## Summary
- Derive target repository path from `TARGET_OWNER`, `TARGET_REPO`, and optional `TARGET_DIR`
- Automatically clone or update the target repo before scanning
- Ensure review workflow passes `TARGET_DIR` to the script
- Inject credentials into git clone/pull to handle private repositories

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c0785ab88c832abe5dac9adcd7d87c