### PR TITLE
test: reset env vars for implement test

### DIFF
--- a/tests/implement.test.ts
+++ b/tests/implement.test.ts
@@ -1,13 +1,17 @@
 import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 
+const OLD_ENV = process.env;
+
 beforeEach(() => {
   vi.resetModules();
+  process.env = { ...OLD_ENV };
   delete process.env.TARGET_OWNER;
   delete process.env.TARGET_REPO;
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  process.env = OLD_ENV;
 });
 
 test('implementTopTask throws when TARGET_REPO missing', async () => {
@@ -17,6 +21,6 @@ test('implementTopTask throws when TARGET_REPO missing', async () => {
     releaseLock: vi.fn().mockResolvedValue(undefined),
   }));
   const { implementTopTask } = await import('../src/cmds/implement.ts');
-  await expect(implementTopTask()).rejects.toThrow('Missing required TARGET_OWNER and TARGET_REPO environment variables');
+  await expect(implementTopTask()).rejects.toThrow('Missing required TARGET_OWNER and TARGET_REPO');
 });
 


### PR DESCRIPTION
## Summary
- reset env vars and modules in implement tests
- match parseRepo error message in implement test

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c079e41320832a98c0e4ff126efc79