### PR TITLE
chore: rebuild dist after env refactor

### DIFF
--- a/dist/lib/env.js
+++ b/dist/lib/env.js
@@ -25,4 +25,22 @@ export function requireEnv(names) {
         }
     }
 }
+/**
+ * Resolve repository configuration from environment variables.
+ *
+ * Required:
+ *   - TARGET_OWNER (e.g. "basstian-ai")
+ *   - TARGET_REPO (e.g. "simple-pim-1754492683911")
+ */
+export function parseRepo() {
+    const targetOwner = process.env.TARGET_OWNER;
+    const targetRepo = process.env.TARGET_REPO;
+    if (!targetOwner || !targetRepo) {
+        throw new Error("Missing required TARGET_OWNER and TARGET_REPO environment variables");
+    }
+    return {
+        owner: targetOwner,
+        repo: targetRepo,
+    };
+}
 // Avoid requiring SUPABASE variables for commands that don't need them.

--- a/dist/lib/github.js
+++ b/dist/lib/github.js
@@ -1,8 +1,6 @@
 import { Octokit } from "octokit";
 import { posix as pathPosix } from "node:path";
-import { ENV } from "./env.js";
-import { parseRepo } from "../env.js";
-export { parseRepo };
+import { ENV, parseRepo } from "./env.js";
 export const gh = new Octokit({ auth: ENV.PAT_TOKEN });
 function formatMessage(msg) {
     if (typeof msg === "string")

--- a/dist/lib/prompts.js
+++ b/dist/lib/prompts.js
@@ -1,6 +1,13 @@
 // src/lib/prompts.ts
 import OpenAI from "openai";
 import { ENV, requireEnv } from "./env.js";
+// OpenAI requires a model name; default to a small one if unset.
+const DEFAULT_OPENAI_MODEL = "gpt-4o-mini";
+/** Ensure a non-empty model value before sending requests. */
+export function getModel() {
+    // Fall back to DEFAULT_OPENAI_MODEL so requests are always valid.
+    return ENV.OPENAI_MODEL || DEFAULT_OPENAI_MODEL;
+}
 /** Lazily get an OpenAI client only when needed */
 function getOpenAI() {
     requireEnv(["OPENAI_API_KEY"]);
@@ -20,7 +27,7 @@ export async function summarizeLogToBug(entries) {
         { role: "user", content: JSON.stringify(entries, null, 2) }
     ];
     const r = await openai.chat.completions.create({
-        model: ENV.OPENAI_MODEL,
+        model: getModel(),
         messages
     });
     return r.choices[0]?.message?.content ?? "";
@@ -38,7 +45,7 @@ export async function reviewToSummary(input) {
         { role: "user", content: JSON.stringify(input, null, 2) }
     ];
     const r = await openai.chat.completions.create({
-        model: ENV.OPENAI_MODEL,
+        model: getModel(),
         messages
     });
     return r.choices[0]?.message?.content ?? "";
@@ -59,7 +66,7 @@ export async function reviewToIdeas(input) {
         { role: "user", content: JSON.stringify(input, null, 2) }
     ];
     const r = await openai.chat.completions.create({
-        model: ENV.OPENAI_MODEL,
+        model: getModel(),
         messages
     });
     return r.choices[0]?.message?.content ?? "";
@@ -80,7 +87,7 @@ export async function synthesizeTasksPrompt(input) {
         { role: "user", content: JSON.stringify(input, null, 2) }
     ];
     const r = await openai.chat.completions.create({
-        model: ENV.OPENAI_MODEL,
+        model: getModel(),
         messages
     });
     return r.choices[0]?.message?.content ?? "";
@@ -108,7 +115,7 @@ export async function implementPlan(input) {
         { role: "user", content: JSON.stringify(input, null, 2) }
     ];
     const r = await openai.chat.completions.create({
-        model: ENV.OPENAI_MODEL,
+        model: getModel(),
         messages
     });
     return r.choices[0]?.message?.content ?? "{}";

--- a/dist/orchestrator.js
+++ b/dist/orchestrator.js
@@ -3,8 +3,8 @@ import { reviewRepo } from "./cmds/review-repo.js";
 import { implementTopTask } from "./cmds/implement.js";
 import { loadState } from "./lib/state.js";
 import { getLatestDeployment } from "./lib/vercel.js";
-import { gh, parseRepo } from "./lib/github.js";
-import { ENV } from "./lib/env.js";
+import { gh } from "./lib/github.js";
+import { parseRepo } from "./lib/env.js";
 async function shouldIngest(state) {
     try {
         const dep = await getLatestDeployment();
@@ -18,8 +18,6 @@ async function shouldIngest(state) {
 }
 async function shouldReview(state) {
     try {
-        if (!ENV.TARGET_OWNER || !ENV.TARGET_REPO)
-            return false;
         const { owner, repo } = parseRepo();
         const resp = await gh.rest.repos.listCommits({ owner, repo, per_page: 1 });
         const latest = resp.data[0]?.sha;


### PR DESCRIPTION
## Summary
- rebuild `dist` outputs
- `dist/orchestrator.js` uses `parseRepo` from env without checking `TARGET_*`
- expose `parseRepo` from `dist/lib/env.js`

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c07ee8e438832a8783b4d2545a4a96