### PR TITLE
Use env helpers in review-repo automation script

### DIFF
--- a/automation/review-repo.ts
+++ b/automation/review-repo.ts
@@ -4,19 +4,13 @@ import crypto from "node:crypto";
 import { exec as cpExec } from "node:child_process";
 import { promisify } from "node:util";
 import { planRepo } from "./prompt";
+// @ts-ignore - compiled JS import
+import { parseRepo, ENV } from "../lib/env.js";
 
 const exec = promisify(cpExec);
 
-const TARGET_OWNER = process.env.TARGET_OWNER;
-const TARGET_REPO = process.env.TARGET_REPO;
-const TARGET_DIR = process.env.TARGET_DIR || "target";
-
-if (!TARGET_OWNER || !TARGET_REPO) {
-  console.error("TARGET_OWNER and TARGET_REPO must be set");
-  process.exit(1);
-}
-
-const TARGET_PATH = path.join(TARGET_DIR, TARGET_OWNER, TARGET_REPO);
+const { owner, repo } = parseRepo();
+const TARGET_PATH = path.join(ENV.TARGET_DIR, owner, repo);
 const MAX_FILES = Number(process.env.MAX_FILES || 180);
 const MAX_SAMPLED_FILES = Number(process.env.MAX_SAMPLED_FILES || 80);
 const MAX_BYTES = Number(process.env.MAX_BYTES_PER_FILE || 1500);
@@ -55,7 +49,7 @@ async function ensureRepo() {
   const ghUser = process.env.GH_USERNAME;
   const pat = process.env.PAT_TOKEN;
   const auth = ghUser && pat ? `${encodeURIComponent(ghUser)}:${encodeURIComponent(pat)}@` : "";
-  const gitUrl = `https://${auth}github.com/${TARGET_OWNER}/${TARGET_REPO}.git`;
+  const gitUrl = `https://${auth}github.com/${owner}/${repo}.git`;
   try {
     await fs.access(path.join(TARGET_PATH, ".git"));
     await exec(`git -C ${TARGET_PATH} remote set-url origin ${gitUrl}`);

--- a/dist/automation/review-repo.js
+++ b/dist/automation/review-repo.js
@@ -4,15 +4,11 @@ import crypto from "node:crypto";
 import { exec as cpExec } from "node:child_process";
 import { promisify } from "node:util";
 import { planRepo } from "./prompt.js";
+// @ts-ignore - compiled JS import
+import { parseRepo, ENV } from "../lib/env.js";
 const exec = promisify(cpExec);
-const TARGET_OWNER = process.env.TARGET_OWNER;
-const TARGET_REPO = process.env.TARGET_REPO;
-const TARGET_DIR = process.env.TARGET_DIR || "target";
-if (!TARGET_OWNER || !TARGET_REPO) {
-    console.error("TARGET_OWNER and TARGET_REPO must be set");
-    process.exit(1);
-}
-const TARGET_PATH = path.join(TARGET_DIR, TARGET_OWNER, TARGET_REPO);
+const { owner, repo } = parseRepo();
+const TARGET_PATH = path.join(ENV.TARGET_DIR, owner, repo);
 const MAX_FILES = Number(process.env.MAX_FILES || 180);
 const MAX_SAMPLED_FILES = Number(process.env.MAX_SAMPLED_FILES || 80);
 const MAX_BYTES = Number(process.env.MAX_BYTES_PER_FILE || 1500);
@@ -48,7 +44,7 @@ async function ensureRepo() {
     const ghUser = process.env.GH_USERNAME;
     const pat = process.env.PAT_TOKEN;
     const auth = ghUser && pat ? `${encodeURIComponent(ghUser)}:${encodeURIComponent(pat)}@` : "";
-    const gitUrl = `https://${auth}github.com/${TARGET_OWNER}/${TARGET_REPO}.git`;
+    const gitUrl = `https://${auth}github.com/${owner}/${repo}.git`;
     try {
         await fs.access(path.join(TARGET_PATH, ".git"));
         await exec(`git -C ${TARGET_PATH} remote set-url origin ${gitUrl}`);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "vitest run",
-    "build": "tsc -p tsconfig.json && tsc automation/prompt.ts automation/review-repo.ts --outDir dist/automation --rootDir automation --module ES2022 --moduleResolution bundler --target ES2022 --esModuleInterop --skipLibCheck && node -e \"const fs=require('fs');const p='dist/automation/review-repo.js';fs.writeFileSync(p,fs.readFileSync(p,'utf8').replace('./prompt','./prompt.js'));\"",
+    "build": "tsc -p tsconfig.json && tsc automation/prompt.ts automation/review-repo.ts --outDir dist/automation --rootDir automation --module ES2022 --moduleResolution bundler --target ES2022 --esModuleInterop --skipLibCheck && node -e \"const fs=require('fs');const p='dist/automation/review-repo.js';let c=fs.readFileSync(p,'utf8');c=c.replace('./prompt','./prompt.js').replace('../src/lib/env.js','../lib/env.js');fs.writeFileSync(p,c);\"",
     "start": "node dist/cli.js",
     "cmd:ingest-logs": "node dist/cli.js ingest-logs",
     "cmd:synthesize-tasks": "node dist/cli.js synthesize-tasks",


### PR DESCRIPTION
## Summary
- use `parseRepo` and `ENV.TARGET_DIR` to derive target repo path
- update build step to rewrite env import in compiled automation script

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c086ed1250832ab9b5e615a882df0b