### PR TITLE
Use ENV for repository configuration

### DIFF
--- a/dist/lib/env.js
+++ b/dist/lib/env.js
@@ -33,8 +33,7 @@ export function requireEnv(names) {
  *   - TARGET_REPO (e.g. "simple-pim-1754492683911")
  */
 export function parseRepo() {
-    const targetOwner = process.env.TARGET_OWNER;
-    const targetRepo = process.env.TARGET_REPO;
+    const { TARGET_OWNER: targetOwner, TARGET_REPO: targetRepo } = ENV;
     if (!targetOwner || !targetRepo) {
         throw new Error("Missing required TARGET_OWNER and TARGET_REPO environment variables");
     }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -35,8 +35,7 @@ export function requireEnv(names: string[]) {
  *   - TARGET_REPO (e.g. "simple-pim-1754492683911")
  */
 export function parseRepo(): { owner: string; repo: string } {
-  const targetOwner = process.env.TARGET_OWNER;
-  const targetRepo = process.env.TARGET_REPO;
+  const { TARGET_OWNER: targetOwner, TARGET_REPO: targetRepo } = ENV;
 
   if (!targetOwner || !targetRepo) {
     throw new Error("Missing required TARGET_OWNER and TARGET_REPO environment variables");

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,37 +1,37 @@
 import { describe, expect, it, vi } from "vitest";
-import { parseRepo } from "../src/lib/env";
+import { ENV, parseRepo } from "../src/lib/env";
 import { gh, getDefaultBranch } from "../src/lib/github";
 
 describe("parseRepo", () => {
   it("parses separate TARGET_OWNER and TARGET_REPO", () => {
-    process.env.TARGET_OWNER = "foo";
-    process.env.TARGET_REPO = "bar";
+    ENV.TARGET_OWNER = "foo";
+    ENV.TARGET_REPO = "bar";
     expect(parseRepo()).toEqual({ owner: "foo", repo: "bar" });
   });
 
   it("throws when missing TARGET_OWNER", () => {
-    delete process.env.TARGET_OWNER;
-    process.env.TARGET_REPO = "bar";
+    ENV.TARGET_OWNER = "";
+    ENV.TARGET_REPO = "bar";
     expect(() => parseRepo()).toThrow("Missing required TARGET_OWNER and TARGET_REPO");
   });
 
   it("throws when missing TARGET_REPO", () => {
-    process.env.TARGET_OWNER = "foo";
-    delete process.env.TARGET_REPO;
+    ENV.TARGET_OWNER = "foo";
+    ENV.TARGET_REPO = "";
     expect(() => parseRepo()).toThrow("Missing required TARGET_OWNER and TARGET_REPO");
   });
 
   it("throws when both missing", () => {
-    delete process.env.TARGET_OWNER;
-    delete process.env.TARGET_REPO;
+    ENV.TARGET_OWNER = "";
+    ENV.TARGET_REPO = "";
     expect(() => parseRepo()).toThrow("Missing required TARGET_OWNER and TARGET_REPO");
   });
 });
 
 describe("Octokit integration", () => {
   it("passes owner and repo to API calls", async () => {
-    process.env.TARGET_OWNER = "foo";
-    process.env.TARGET_REPO = "bar";
+    ENV.TARGET_OWNER = "foo";
+    ENV.TARGET_REPO = "bar";
     const spy = vi
       .spyOn(gh.rest.repos, "get")
       .mockResolvedValue({ data: { default_branch: "main" } } as any);

--- a/tests/review-repo.test.ts
+++ b/tests/review-repo.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { ENV } from '../src/lib/env.js';
 
 const envVars = {
   TARGET_OWNER: 'o',
@@ -53,15 +54,15 @@ vi.mock('../src/lib/supabase.js', () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  process.env.TARGET_OWNER = envVars.TARGET_OWNER;
-  process.env.TARGET_REPO = envVars.TARGET_REPO;
+  ENV.TARGET_OWNER = envVars.TARGET_OWNER;
+  ENV.TARGET_REPO = envVars.TARGET_REPO;
   process.env.SUPABASE_URL = envVars.SUPABASE_URL;
   process.env.SUPABASE_SERVICE_ROLE_KEY = envVars.SUPABASE_SERVICE_ROLE_KEY;
 });
 
 afterEach(() => {
-  delete process.env.TARGET_OWNER;
-  delete process.env.TARGET_REPO;
+  ENV.TARGET_OWNER = '';
+  ENV.TARGET_REPO = '';
   delete process.env.SUPABASE_URL;
   delete process.env.SUPABASE_SERVICE_ROLE_KEY;
 });
@@ -74,7 +75,7 @@ test('reviewRepo throws on invalid ideas YAML', async () => {
 });
 
 test('reviewRepo throws when repo env vars are missing', async () => {
-  delete process.env.TARGET_OWNER;
+  ENV.TARGET_OWNER = '';
   const { reviewRepo } = await import('../src/cmds/review-repo.ts');
   await expect(reviewRepo()).rejects.toThrow('Missing required TARGET_OWNER and TARGET_REPO environment variables');
 });


### PR DESCRIPTION
## Summary
- read TARGET_OWNER and TARGET_REPO from ENV in `parseRepo`
- adjust tests to configure repo via ENV
- rebuild dist

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c08a93bd8c832a98c69f0b39e39fff