### PR TITLE
Validate repository access before creating commit tree

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -175,6 +175,21 @@ export async function commitMany(
     });
   }
 
+  try {
+    await gh.rest.repos.get({ owner, repo });
+  } catch (e: any) {
+    if (e?.status === 404 || e?.status === 403) {
+      throw new Error(
+        `Access to repository ${owner}/${repo} failed with status ${e.status}. Please verify TARGET_OWNER, TARGET_REPO, and PAT_TOKEN permissions.`
+      );
+    }
+    throw e;
+  }
+
+  console.log(
+    `commitMany target: owner=${owner} repo=${repo} branch=${branch} base=${latestCommit.data.tree.sha}`
+  );
+
   const tree = await git.createTree({
     owner,
     repo,


### PR DESCRIPTION
## Summary
- Check repository accessibility via `gh.rest.repos.get` before `git.createTree`
- Log owner, repo, branch, and base tree SHA for debugging
- Improve error messaging to help validate TARGET_OWNER, TARGET_REPO, and PAT_TOKEN

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c09d00ba0c832aaef0be0676982d7d