### PR TITLE
Require PAT_TOKEN for commitMany

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Project-agnostic behavior
 
 Setup requirements (minimal)
 	•	Credentials: GitHub token (repo), Deploy provider token (e.g., Vercel) + project id.
+	•	PAT_TOKEN must include `repo` scope and be authorized for the target repository.
 	•	Permissions: Push rights (or PR-only mode), access to build logs.
 	•	Config: agent/config.json (or zero-config with sensible defaults).
 

--- a/dist/lib/github.js
+++ b/dist/lib/github.js
@@ -1,6 +1,6 @@
 import { Octokit } from "octokit";
 import { posix as pathPosix } from "node:path";
-import { ENV, parseRepo } from "./env.js";
+import { ENV, parseRepo, requireEnv } from "./env.js";
 export const gh = new Octokit({ auth: ENV.PAT_TOKEN });
 function formatMessage(msg) {
     if (typeof msg === "string")
@@ -93,6 +93,7 @@ export async function upsertFile(path, updater, message, opts) {
     });
 }
 export async function commitMany(files, message, opts) {
+    requireEnv(["PAT_TOKEN"]);
     const { owner, repo } = parseRepo();
     const ref = opts?.branch;
     const msg = formatMessage(message);

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,6 +1,6 @@
 import { Octokit } from "octokit";
 import { posix as pathPosix } from "node:path";
-import { ENV, parseRepo } from "./env.js";
+import { ENV, parseRepo, requireEnv } from "./env.js";
 
 export const gh = new Octokit({ auth: ENV.PAT_TOKEN });
 
@@ -108,6 +108,7 @@ export async function commitMany(
   message: CommitMessage,
   opts?: { branch?: string }
 ) {
+  requireEnv(["PAT_TOKEN"]);
   const { owner, repo } = parseRepo();
   const ref = opts?.branch;
   const msg = formatMessage(message);


### PR DESCRIPTION
## Summary
- enforce presence of `PAT_TOKEN` in `commitMany`
- document required `PAT_TOKEN` scope in README

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c09f5ff984832a9579eb8fc1873efa