### PR TITLE
Add test for commitMany createTree error handling

### DIFF
--- a/dist/lib/github.js
+++ b/dist/lib/github.js
@@ -143,12 +143,20 @@ export async function commitMany(files, message, opts) {
             sha: blob.data.sha
         });
     }
-    const tree = await git.createTree({
-        owner,
-        repo,
-        base_tree: latestCommit.data.tree.sha,
-        tree: treeEntries
-    });
+    let tree;
+    try {
+        tree = await git.createTree({
+            owner,
+            repo,
+            base_tree: latestCommit.data.tree.sha,
+            tree: treeEntries
+        });
+    } catch (e) {
+        if ((e == null ? void 0 : e.status) === 404 || (e == null ? void 0 : e.status) === 403) {
+            throw new Error(`Access to repository ${owner}/${repo} failed with status ${e.status}. Please verify TARGET_OWNER, TARGET_REPO, and PAT_TOKEN permissions.`);
+        }
+        throw e;
+    }
     const newCommit = await git.createCommit({
         owner,
         repo,

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -191,12 +191,22 @@ export async function commitMany(
     `commitMany target: owner=${owner} repo=${repo} branch=${branch} base=${latestCommit.data.tree.sha}`
   );
 
-  const tree = await git.createTree({
-    owner,
-    repo,
-    base_tree: latestCommit.data.tree.sha,
-    tree: treeEntries
-  });
+  let tree: any;
+  try {
+    tree = await git.createTree({
+      owner,
+      repo,
+      base_tree: latestCommit.data.tree.sha,
+      tree: treeEntries
+    });
+  } catch (e: any) {
+    if (e?.status === 404 || e?.status === 403) {
+      throw new Error(
+        `Access to repository ${owner}/${repo} failed with status ${e.status}. Please verify TARGET_OWNER, TARGET_REPO, and PAT_TOKEN permissions.`
+      );
+    }
+    throw e;
+  }
 
   const newCommit = await git.createCommit({
     owner,

--- a/tests/commit-many.test.ts
+++ b/tests/commit-many.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { commitMany, gh } from "../src/lib/github";
+import { ENV } from "../src/lib/env";
+
+describe("commitMany", () => {
+  it("surfaces a descriptive error when git.createTree returns 404", async () => {
+    process.env.PAT_TOKEN = "token";
+    ENV.PAT_TOKEN = "token";
+    ENV.TARGET_OWNER = "foo";
+    ENV.TARGET_REPO = "bar";
+
+    vi.spyOn(gh.rest.git, "getRef").mockResolvedValue({
+      data: { object: { sha: "headsha" } }
+    } as any);
+    vi.spyOn(gh.rest.git, "getCommit").mockResolvedValue({
+      data: { tree: { sha: "treesha" } }
+    } as any);
+    vi.spyOn(gh.rest.git, "getTree").mockResolvedValue({ data: { tree: [] } } as any);
+    vi.spyOn(gh.rest.git, "createBlob").mockResolvedValue({ data: { sha: "blobsha" } } as any);
+    vi.spyOn(gh.rest.repos, "get").mockResolvedValue({} as any);
+
+    const createTreeMock = vi
+      .spyOn(gh.rest.git, "createTree")
+      .mockRejectedValue({ status: 404, message: "Not Found" });
+
+    await expect(
+      commitMany([{ path: "file.txt", content: "hello" }], "msg", { branch: "main" })
+    ).rejects.toThrow(
+      "Access to repository foo/bar failed with status 404. Please verify TARGET_OWNER, TARGET_REPO, and PAT_TOKEN permissions."
+    );
+
+    expect(createTreeMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- handle git.createTree 404/403 errors in commitMany
- add test asserting commitMany surfaces repository access error when git.createTree fails

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c0a1ffac48832ab27d4b44b6298de8