### PR TITLE
docs: clarify bug summary storage

### DIFF
--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -27,7 +27,7 @@ export type LogEntryForBug = {
 
 /**
  * Turn runtime/build log entries into a short bug description list.
- * Return is free-form markdown/text that the caller writes into bugs.md.
+ * Return is free-form markdown/text that the caller stores in Supabase.
  */
 export async function summarizeLogToBug(entries: LogEntryForBug[]): Promise<string> {
   const openai = getOpenAI();


### PR DESCRIPTION
## Summary
- clarify that log summaries are saved to Supabase instead of a local bugs.md file

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c0a4ad6ad8832aa292ead2d56c82a6