### PR TITLE
Use singular bug type for roadmap fetch

### DIFF
--- a/dist/cmds/review-repo.js
+++ b/dist/cmds/review-repo.js
@@ -17,7 +17,7 @@ export async function reviewRepo() {
             const data = (await sbRequest(`roadmap_items?select=content&type=eq.${type}`));
             return data ? data.map((r) => r.content).join("\n") : "";
         }
-        const roadmapTypes = ["vision", "task", "bugs", "done", "new"];
+        const roadmapTypes = ["vision", "task", "bug", "done", "new"];
         const [vision, tasks, bugs, done, ideas] = await Promise.all(roadmapTypes.map(fetchRoadmap));
         const state = await loadState();
         const { owner, repo } = parseRepo();

--- a/src/cmds/review-repo.ts
+++ b/src/cmds/review-repo.ts
@@ -17,7 +17,7 @@ export async function reviewRepo() {
       )) as { content: string }[] | undefined;
       return data ? data.map((r) => r.content).join("\n") : "";
     }
-    const roadmapTypes = ["vision", "task", "bugs", "done", "new"];
+    const roadmapTypes = ["vision", "task", "bug", "done", "new"];
     const [vision, tasks, bugs, done, ideas] = await Promise.all(
       roadmapTypes.map(fetchRoadmap),
     );

--- a/tests/review-repo.test.ts
+++ b/tests/review-repo.test.ts
@@ -122,3 +122,11 @@ test('reviewRepo skips quoting YAML block scalars', async () => {
   const ideasBody = JSON.parse(postCalls[1][1].body);
   expect(ideasBody[0].content).toBe('first\nsecond\n');
 });
+
+test('reviewRepo fetches bug roadmap items', async () => {
+  const { reviewRepo } = await import('../src/cmds/review-repo.ts');
+  reviewToIdeas.mockResolvedValue('queue:\n');
+  await reviewRepo();
+  const paths = sbRequest.mock.calls.map((call) => call[0]);
+  expect(paths).toContain('roadmap_items?select=content&type=eq.bug');
+});


### PR DESCRIPTION
## Summary
- query Supabase with `type=eq.bug` when fetching roadmap items in `review-repo`
- ensure downstream code still receives `bugs` array
- add regression test verifying the bug query

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c0a9a7cd60832a9c161d3f6a3364c0