### PR TITLE
Clarify Supabase backlog source in prompts

### DIFF
--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -62,7 +62,7 @@ export async function reviewToSummary(input: {
     {
       role: "system" as const,
       content:
-        "You are an experienced software architect. Review the provided repository context and write a high-level summary of the current status, recent activity, and potential areas for improvement. Output should be human-readable markdown, suitable for a technical project manager."
+        "You are an experienced software architect. Review the provided repository context and write a high-level summary of the current status, recent activity, and potential areas for improvement. Backlog data (tasks, bugs, done, ideas) is supplied by Supabase; no local files are expected. Output should be human-readable markdown, suitable for a technical project manager."
     },
     { role: "user" as const, content: JSON.stringify(input, null, 2) }
   ];
@@ -90,7 +90,7 @@ export async function reviewToIdeas(input: {
       {
         role: "system" as const,
         content:
-          "You are an experienced software architect. Based on the provided summary and other context, propose concise, actionable items for a code bot. Include tasks that make visible progress for the end user." +
+          "You are an experienced software architect. Based on the provided summary and other context, propose concise, actionable items for a code bot. Backlog data (tasks, bugs, done, ideas) comes from Supabase; no local files are expected. Include tasks that make visible progress for the end user." +
           "Return ONLY YAML with the shape:\nqueue:\n  - id: <leave blank or omit>\n    title: <short>\n    details: <1-3 lines>\n    created: <ISO>\n" +
           "\nAvoid duplicates vs the provided lists. Focus on the opportunities identified in the summary."
       },


### PR DESCRIPTION
## Summary
- explain that backlog data comes from Supabase in reviewToSummary and reviewToIdeas prompts

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c0b5924814832a9a137c5b95d2dffe