### PR TITLE
Use fromId for Vercel log pagination

### DIFF
--- a/dist/lib/vercel.js
+++ b/dist/lib/vercel.js
@@ -29,7 +29,7 @@ export async function getBuildLogs(deploymentId, opts = {}) {
         url.searchParams.set("teamId", ENV.VERCEL_TEAM_ID);
     const { fromId, from, until, limit, direction } = opts;
     if (fromId)
-        url.searchParams.set("from", fromId);
+        url.searchParams.set("fromId", fromId);
     else if (from)
         url.searchParams.set("from", from);
     if (until)

--- a/src/lib/vercel.ts
+++ b/src/lib/vercel.ts
@@ -37,7 +37,7 @@ export async function getBuildLogs(
   );
   if (ENV.VERCEL_TEAM_ID) url.searchParams.set("teamId", ENV.VERCEL_TEAM_ID);
   const { fromId, from, until, limit, direction } = opts;
-  if (fromId) url.searchParams.set("from", fromId);
+  if (fromId) url.searchParams.set("fromId", fromId);
   else if (from) url.searchParams.set("from", from);
   if (until) url.searchParams.set("until", until);
   if (limit !== undefined) url.searchParams.set("limit", String(limit));

--- a/tests/ingest-logs.test.ts
+++ b/tests/ingest-logs.test.ts
@@ -58,6 +58,8 @@ test('ingestLogs only fetches new log entries on repeat runs', async () => {
       expect.objectContaining({ fromId: 'id3' })
     );
     expect(insertRoadmap).toHaveBeenCalledTimes(2);
+    expect(insertRoadmap.mock.calls[0][0]).toHaveLength(2);
+    expect(insertRoadmap.mock.calls[1][0]).toHaveLength(1);
     expect(saveState.mock.calls[1][0].ingest.lastRowIds).toEqual(['id2', 'id3']);
     expect(saveState.mock.calls[2][0].ingest.lastRowIds).toEqual(['id2', 'id3']);
   });

--- a/tests/vercel.test.ts
+++ b/tests/vercel.test.ts
@@ -33,7 +33,7 @@ afterEach(() => {
     const { getBuildLogs } = await import('../src/lib/vercel.ts');
     await getBuildLogs('dep1', { fromId: '123' });
   const url = fetchMock.mock.calls[0][0] as URL;
-  expect(url.searchParams.get('from')).toBe('123');
+  expect(url.searchParams.get('fromId')).toBe('123');
 });
 
   test('getBuildLogs rejects on timeout', async () => {


### PR DESCRIPTION
## Summary
- use the `fromId` query parameter for build-log pagination
- expand tests to exercise fromId-based pagination and check for duplicate log entries

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c0b6b22e88832aaa39f8bf908f0eb3