### PR TITLE
Handle missing Vercel build logs

### DIFF
--- a/src/lib/vercel.ts
+++ b/src/lib/vercel.ts
@@ -59,6 +59,10 @@ export async function getBuildLogs(
   } finally {
     clearTimeout(t);
   }
+  if (res.status === 404) {
+    console.warn("Vercel build-logs not found (404)");
+    return [];
+  }
   if (!res.ok) throw new Error(`Vercel build-logs failed: ${res.status}`);
   const text = await res.text();
   return text

--- a/tests/vercel.test.ts
+++ b/tests/vercel.test.ts
@@ -7,13 +7,23 @@ beforeEach(() => {
   process.env.VERCEL_TEAM_ID = 'team';
 });
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.useRealTimers();
-  delete process.env.VERCEL_PROJECT_ID;
-  delete process.env.VERCEL_TOKEN;
-  delete process.env.VERCEL_TEAM_ID;
-});
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    delete process.env.VERCEL_PROJECT_ID;
+    delete process.env.VERCEL_TOKEN;
+    delete process.env.VERCEL_TEAM_ID;
+  });
+
+  test('getBuildLogs returns empty array on 404', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 404, text: async () => '' } as any);
+    vi.stubGlobal('fetch', fetchMock);
+    const warnMock = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { getBuildLogs } = await import('../src/lib/vercel.ts');
+    const res = await getBuildLogs('dep1');
+    expect(res).toEqual([]);
+    expect(warnMock).toHaveBeenCalled();
+  });
 
   test('getBuildLogs passes paging params', async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => '' } as any);


### PR DESCRIPTION
## Summary
- handle 404 from Vercel build log API by returning an empty array
- test that getBuildLogs returns [] and warns on 404

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c168845a34832aa6b8fb4ca9f4e54c