### PR TITLE
feat: include repo tree in implement

### DIFF
--- a/dist/cmds/implement.js
+++ b/dist/cmds/implement.js
@@ -47,7 +47,11 @@ export async function implementTopTask() {
         let repoTree = [];
         try {
             const treeOutput = execSync("git ls-files", { encoding: "utf8" });
-            repoTree = treeOutput.split(/\r?\n/).filter(Boolean);
+            const repoTreeLimit = parseInt(process.env.REPO_TREE_LIMIT || "1000", 10);
+            repoTree = treeOutput
+                .split(/\r?\n/)
+                .filter(Boolean)
+                .slice(0, repoTreeLimit);
         }
         catch (err) {
             console.warn("Failed to list repo files", err);

--- a/dist/cmds/implement.js
+++ b/dist/cmds/implement.js
@@ -44,7 +44,14 @@ export async function implementTopTask() {
             targetBranch = undefined;
         }
         // Optional path guard
-        const repoTree = [];
+        let repoTree = [];
+        try {
+            const treeOutput = execSync("git ls-files", { encoding: "utf8" });
+            repoTree = treeOutput.split(/\r?\n/).filter(Boolean);
+        }
+        catch (err) {
+            console.warn("Failed to list repo files", err);
+        }
         const planJson = await implementPlan({ vision, done: "", topTask: top, repoTree });
         let plan = {};
         try {

--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -55,7 +55,11 @@ export async function implementTopTask() {
     let repoTree: string[] = [];
     try {
       const treeOutput = execSync("git ls-files", { encoding: "utf8" });
-      repoTree = treeOutput.split(/\r?\n/).filter(Boolean);
+      const repoTreeLimit = parseInt(process.env.REPO_TREE_LIMIT || "1000", 10);
+      repoTree = treeOutput
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .slice(0, repoTreeLimit);
     } catch (err) {
       console.warn("Failed to list repo files", err);
     }

--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -52,7 +52,13 @@ export async function implementTopTask() {
     }
 
     // Optional path guard
-    const repoTree: string[] = [];
+    let repoTree: string[] = [];
+    try {
+      const treeOutput = execSync("git ls-files", { encoding: "utf8" });
+      repoTree = treeOutput.split(/\r?\n/).filter(Boolean);
+    } catch (err) {
+      console.warn("Failed to list repo files", err);
+    }
     const planJson = await implementPlan({ vision, done: "", topTask: top, repoTree });
     let plan: any = {};
     try { plan = JSON.parse(planJson); } catch { plan = {}; }

--- a/tests/implement.test.ts
+++ b/tests/implement.test.ts
@@ -78,3 +78,60 @@ test('implementTopTask passes repoTree to implementPlan', async () => {
   expect(captured!.length).toBeGreaterThan(0);
 });
 
+test('implementTopTask caps repoTree length', async () => {
+  process.env.TARGET_OWNER = 'o';
+  process.env.TARGET_REPO = 'r';
+  process.env.REPO_TREE_LIMIT = '2';
+
+  vi.doMock('node:child_process', () => ({
+    execSync: vi.fn((cmd: string) =>
+      cmd.includes('git ls-files')
+        ? Array.from({ length: 5 }, (_, i) => `f${i}`).join('\n')
+        : ''
+    ),
+  }));
+
+  vi.doMock('../src/lib/lock.js', () => ({
+    acquireLock: vi.fn().mockResolvedValue(true),
+    releaseLock: vi.fn().mockResolvedValue(undefined),
+  }));
+
+  const mockTask = { id: '1', title: 't', content: 'c', priority: 1 };
+  vi.doMock('../src/lib/supabase.js', () => ({
+    supabase: {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            or: () => ({
+              order: () => ({
+                limit: () => Promise.resolve({ data: [mockTask], error: null }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    },
+  }));
+
+  let captured: string[] | undefined;
+  vi.doMock('../src/lib/prompts.js', () => ({
+    implementPlan: vi.fn(async (input) => {
+      captured = input.repoTree;
+      return JSON.stringify({ operations: [] });
+    }),
+  }));
+
+  vi.doMock('../src/lib/github.js', () => ({
+    readFile: vi.fn().mockResolvedValue(''),
+    commitMany: vi.fn().mockResolvedValue(undefined),
+    resolveRepoPath: (p: string) => p,
+    ensureBranch: vi.fn(),
+    getDefaultBranch: vi.fn().mockResolvedValue('main'),
+  }));
+
+  const { implementTopTask } = await import('../src/cmds/implement.ts');
+  await implementTopTask();
+
+  expect(captured).toEqual(['f0', 'f1']);
+});
+

--- a/tests/implement.test.ts
+++ b/tests/implement.test.ts
@@ -16,11 +16,65 @@ afterEach(() => {
 
 test('implementTopTask throws when TARGET_REPO missing', async () => {
   process.env.TARGET_OWNER = 'o';
-  vi.mock('../src/lib/lock.js', () => ({
+  process.env.PAT_TOKEN = 't';
+  vi.doMock('../src/lib/lock.js', () => ({
     acquireLock: vi.fn().mockResolvedValue(true),
     releaseLock: vi.fn().mockResolvedValue(undefined),
   }));
   const { implementTopTask } = await import('../src/cmds/implement.ts');
   await expect(implementTopTask()).rejects.toThrow('Missing required TARGET_OWNER and TARGET_REPO');
+});
+
+test('implementTopTask passes repoTree to implementPlan', async () => {
+  process.env.TARGET_OWNER = 'o';
+  process.env.TARGET_REPO = 'r';
+
+  vi.doMock('node:child_process', () => ({
+    execSync: vi.fn((cmd: string) => (cmd.includes('git ls-files') ? 'a\nb\n' : '')),
+  }));
+
+  vi.doMock('../src/lib/lock.js', () => ({
+    acquireLock: vi.fn().mockResolvedValue(true),
+    releaseLock: vi.fn().mockResolvedValue(undefined),
+  }));
+
+  const mockTask = { id: '1', title: 't', content: 'c', priority: 1 };
+  vi.doMock('../src/lib/supabase.js', () => ({
+    supabase: {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            or: () => ({
+              order: () => ({
+                limit: () => Promise.resolve({ data: [mockTask], error: null }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    },
+  }));
+
+  let captured: string[] | undefined;
+  vi.doMock('../src/lib/prompts.js', () => ({
+    implementPlan: vi.fn(async (input) => {
+      captured = input.repoTree;
+      return JSON.stringify({ operations: [] });
+    }),
+  }));
+
+  vi.doMock('../src/lib/github.js', () => ({
+    readFile: vi.fn().mockResolvedValue(''),
+    commitMany: vi.fn().mockResolvedValue(undefined),
+    resolveRepoPath: (p: string) => p,
+    ensureBranch: vi.fn(),
+    getDefaultBranch: vi.fn().mockResolvedValue('main'),
+  }));
+
+  const { implementTopTask } = await import('../src/cmds/implement.ts');
+  await implementTopTask();
+
+  expect(captured).toBeDefined();
+  expect(captured!.length).toBeGreaterThan(0);
 });
 


### PR DESCRIPTION
## Summary
- collect tracked files with `git ls-files` before planning task implementation
- send file list to `implementPlan`
- test that implement plan receives repo tree

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c19ec2280c832ab10b414b0a300404