### PR TITLE
fix: cap repo tree in implement command

### DIFF
--- a/dist/cmds/implement.js
+++ b/dist/cmds/implement.js
@@ -47,7 +47,11 @@ export async function implementTopTask() {
         let repoTree = [];
         try {
             const treeOutput = execSync("git ls-files", { encoding: "utf8" });
-            repoTree = treeOutput.split(/\r?\n/).filter(Boolean);
+            const repoTreeLimit = parseInt(process.env.REPO_TREE_LIMIT || "1000", 10);
+            repoTree = treeOutput
+                .split(/\r?\n/)
+                .filter(Boolean)
+                .slice(0, repoTreeLimit);
         }
         catch (err) {
             console.warn("Failed to list repo files", err);

--- a/src/cmds/implement.ts
+++ b/src/cmds/implement.ts
@@ -55,7 +55,11 @@ export async function implementTopTask() {
     let repoTree: string[] = [];
     try {
       const treeOutput = execSync("git ls-files", { encoding: "utf8" });
-      repoTree = treeOutput.split(/\r?\n/).filter(Boolean);
+      const repoTreeLimit = parseInt(process.env.REPO_TREE_LIMIT || "1000", 10);
+      repoTree = treeOutput
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .slice(0, repoTreeLimit);
     } catch (err) {
       console.warn("Failed to list repo files", err);
     }

--- a/tests/implement.test.ts
+++ b/tests/implement.test.ts
@@ -78,3 +78,60 @@ test('implementTopTask passes repoTree to implementPlan', async () => {
   expect(captured!.length).toBeGreaterThan(0);
 });
 
+test('implementTopTask caps repoTree length', async () => {
+  process.env.TARGET_OWNER = 'o';
+  process.env.TARGET_REPO = 'r';
+  process.env.REPO_TREE_LIMIT = '2';
+
+  vi.doMock('node:child_process', () => ({
+    execSync: vi.fn((cmd: string) =>
+      cmd.includes('git ls-files')
+        ? Array.from({ length: 5 }, (_, i) => `f${i}`).join('\n')
+        : ''
+    ),
+  }));
+
+  vi.doMock('../src/lib/lock.js', () => ({
+    acquireLock: vi.fn().mockResolvedValue(true),
+    releaseLock: vi.fn().mockResolvedValue(undefined),
+  }));
+
+  const mockTask = { id: '1', title: 't', content: 'c', priority: 1 };
+  vi.doMock('../src/lib/supabase.js', () => ({
+    supabase: {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            or: () => ({
+              order: () => ({
+                limit: () => Promise.resolve({ data: [mockTask], error: null }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    },
+  }));
+
+  let captured: string[] | undefined;
+  vi.doMock('../src/lib/prompts.js', () => ({
+    implementPlan: vi.fn(async (input) => {
+      captured = input.repoTree;
+      return JSON.stringify({ operations: [] });
+    }),
+  }));
+
+  vi.doMock('../src/lib/github.js', () => ({
+    readFile: vi.fn().mockResolvedValue(''),
+    commitMany: vi.fn().mockResolvedValue(undefined),
+    resolveRepoPath: (p: string) => p,
+    ensureBranch: vi.fn(),
+    getDefaultBranch: vi.fn().mockResolvedValue('main'),
+  }));
+
+  const { implementTopTask } = await import('../src/cmds/implement.ts');
+  await implementTopTask();
+
+  expect(captured).toEqual(['f0', 'f1']);
+});
+


### PR DESCRIPTION
## Summary
- cap repo file list passed to implementPlan via `REPO_TREE_LIMIT`
- test that implementTopTask truncates repo tree

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c1a2e97250832abdb2a9b9fcc23bc5