### PR TITLE
fix: prefix branch in commitMany paths

### DIFF
--- a/dist/lib/github.js
+++ b/dist/lib/github.js
@@ -135,9 +135,11 @@ export async function commitMany(files, message, opts) {
     const treeEntries = [];
     for (const f of files) {
         const safePath = resolveRepoPath(f.path);
-        const treePath = safePath.startsWith(`${branch}/`)
-            ? safePath
-            : pathPosix.join(branch, safePath);
+        const treePath = ref
+            ? safePath.startsWith(`${ref}/`)
+                ? safePath
+                : pathPosix.join(ref, safePath)
+            : safePath;
         if ("content" in f) {
             const blob = await git.createBlob({
                 owner,

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -163,9 +163,11 @@ export async function commitMany(
   }> = [];
   for (const f of files) {
     const safePath = resolveRepoPath(f.path);
-    const treePath = safePath.startsWith(`${branch}/`)
-      ? safePath
-      : pathPosix.join(branch, safePath);
+    const treePath = ref
+      ? safePath.startsWith(`${ref}/`)
+        ? safePath
+        : pathPosix.join(ref, safePath)
+      : safePath;
     if ("content" in f) {
       const blob = await git.createBlob({
         owner,

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -121,7 +121,13 @@ export async function commitMany(
     );
     for (const f of files) {
       const safePath = resolveRepoPath(f.path);
-      console.log(`  - ${safePath} (${f.content.length} bytes)`);
+      const treePath = ref
+        ? safePath.startsWith(`${ref}/`)
+          ? safePath
+          : pathPosix.join(ref, safePath)
+        : safePath;
+      const size = "content" in f ? f.content.length : 0;
+      console.log(`  - ${treePath} (${size} bytes)`);
     }
     return;
   }
@@ -157,6 +163,9 @@ export async function commitMany(
   }> = [];
   for (const f of files) {
     const safePath = resolveRepoPath(f.path);
+    const treePath = safePath.startsWith(`${branch}/`)
+      ? safePath
+      : pathPosix.join(branch, safePath);
     if ("content" in f) {
       const blob = await git.createBlob({
         owner,
@@ -165,7 +174,7 @@ export async function commitMany(
         encoding: "utf-8"
       });
       const mode =
-        (modeByPath.get(safePath) as
+        (modeByPath.get(treePath) as
           | "100644"
           | "100755"
           | "040000"
@@ -173,13 +182,13 @@ export async function commitMany(
           | "120000"
           | undefined) || "100644";
       treeEntries.push({
-        path: safePath,
+        path: treePath,
         mode,
         type: "blob",
         sha: blob.data.sha
       });
     } else {
-      treeEntries.push({ path: safePath, mode: f.mode, type: "blob", sha: null });
+      treeEntries.push({ path: treePath, mode: f.mode, type: "blob", sha: null });
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure commitMany prefixes branch directory only once when building tree paths
- log branch-aware paths during dry runs

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c1a8241dcc832a96a673751cc15b85