### PR TITLE
Fix branch prefixing in commitMany

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -188,11 +188,7 @@ export async function commitMany(
   }> = [];
   for (const f of files) {
     const safePath = resolveRepoPath(f.path);
-    const treePath = ref
-      ? safePath.startsWith(`${ref}/`)
-        ? safePath
-        : pathPosix.join(ref, safePath)
-      : safePath;
+    const treePath = safePath;
     if ("content" in f) {
       const blob = await git.createBlob({
         owner,

--- a/tests/commit-many.test.ts
+++ b/tests/commit-many.test.ts
@@ -85,8 +85,8 @@ describe("commitMany", () => {
       repo: "bar",
       base_tree: "treesha",
       tree: [
-        { path: "main/keep.txt", mode: "100644", type: "blob", sha: "blobsha" },
-        { path: "main/remove.txt", mode: "100644", type: "blob", sha: null }
+        { path: "keep.txt", mode: "100644", type: "blob", sha: "blobsha" },
+        { path: "remove.txt", mode: "100644", type: "blob", sha: null }
       ]
     });
   });


### PR DESCRIPTION
## Summary
- avoid prefixing branch names when building commit tree entries
- adjust tests to match tree entry path handling

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c3300d6e30832ab3b895f9c5f04e9c