### PR TITLE
Improve createTree error diagnostics

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -231,12 +231,18 @@ export async function commitMany(
       tree: treeEntries
     });
   } catch (e: any) {
+    const url = e?.request?.request?.url || e?.request?.url;
+    const scopes = e?.response?.headers?.["x-oauth-scopes"];
+    if (scopes) console.error(`Token scopes: ${scopes}`);
+    if (e?.status === 404) {
+      console.error(`Branch ${branch} may not exist.`);
+    }
     if (e?.status === 404 || e?.status === 403) {
       throw new Error(
-        `Access to repository ${owner}/${repo} failed with status ${e.status}. Please verify TARGET_OWNER, TARGET_REPO, and PAT_TOKEN permissions.`
+        `Access to repository ${owner}/${repo} failed with status ${e.status}. Request: ${url}. Error: ${e.message}. Please verify TARGET_OWNER, TARGET_REPO, PAT_TOKEN permissions, and that branch ${branch} exists.`
       );
     }
-    throw e;
+    throw new Error(`${e.message}${url ? ` (URL: ${url})` : ""}`);
   }
 
   const newCommit = await git.createCommit({

--- a/tests/commit-many.test.ts
+++ b/tests/commit-many.test.ts
@@ -36,7 +36,7 @@ describe("commitMany", () => {
     await expect(
       commitMany([{ path: "file.txt", content: "hello" }], "msg", { branch: "main" })
     ).rejects.toThrow(
-      "Access to repository foo/bar failed with status 404. Please verify TARGET_OWNER, TARGET_REPO, and PAT_TOKEN permissions."
+      /Access to repository foo\/bar failed with status 404\. Request: .* Error: Not Found\. Please verify TARGET_OWNER, TARGET_REPO, PAT_TOKEN permissions, and that branch main exists\./
     );
 
     expect(createTreeMock).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- include request URL and message in createTree error handling
- log token scopes and hint when branch may not exist
- adjust tests for new error format

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c33019d05c832aa6d5a4affe8fb550